### PR TITLE
Use private libs field for @LIBS@ in cfitsio.pc

### DIFF
--- a/cfitsio.pc.in
+++ b/cfitsio.pc.in
@@ -6,6 +6,6 @@ includedir=@includedir@
 Name: cfitsio
 Description: FITS File Subroutine Library
 Version: @CFITSIO_MAJOR@.@CFITSIO_MINOR@
-Libs: -L${libdir} -lcfitsio @LIBS@
-Libs.private: -lm
+Libs: -L${libdir} -lcfitsio
+Libs.private: -lm @LIBS@
 Cflags: -I${includedir}


### PR DESCRIPTION
Currently (I think) the pkgconfig file includes the dependency libs in the non-private `Libs` field, effectively forcing downstream libraries to link against cfitsio's dependencies when using pkgconfig. This just moves the `@LIBS@` variable in to the `Libs.private` field to prevent overlinking for dependents.