### PR TITLE
Fix various typos

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -181,7 +181,7 @@ distclean:	clean
 	-	/bin/rm -f Makefile cfitsio.pc config.log config.status configure.lineno
 
 # Make target which outputs the list of the .o contained in the cfitsio lib
-# usefull to build a single big shared library containing Tcl/Tk and other
+# useful to build a single big shared library containing Tcl/Tk and other
 # extensions.  used for the Tcl Plugin. 
 
 cfitsioLibObjs:

--- a/buffers.c
+++ b/buffers.c
@@ -239,7 +239,7 @@ int ffpbytoff(fitsfile *fptr, /* I - FITS file pointer                   */
       }
       else
       {
-        ioptr  += (offset + nwrite);  /* increment IO bufer pointer */
+        ioptr  += (offset + nwrite);  /* increment IO buffer pointer */
         nspace -= (offset + nwrite);
       }
 
@@ -422,7 +422,7 @@ int ffgbytoff(fitsfile *fptr, /* I - FITS file pointer                   */
       }
       else
       {
-        ioptr  += (offset + nread);  /* increment IO bufer pointer */
+        ioptr  += (offset + nread);  /* increment IO buffer pointer */
         nspace -= (offset + nread);
       }
 
@@ -737,7 +737,7 @@ ffseek(Fptr, filepos);
     return(*status);       
 }
 /*--------------------------------------------------------------------------*/
-int ffgrsz( fitsfile *fptr, /* I - FITS file pionter                        */
+int ffgrsz( fitsfile *fptr, /* I - FITS file pointer                        */
             long *ndata,    /* O - optimal amount of data to access         */
             int  *status)   /* IO - error status                            */
 /*

--- a/cfileio.c
+++ b/cfileio.c
@@ -1101,7 +1101,7 @@ move2hdu:
 
        if (rownum == 0)
        {
-          ffpmsg("row statisfying this expression doesn't exist::");
+          ffpmsg("row satisfying this expression doesn't exist::");
           ffpmsg(rowexpress);
           ffpmsg("Could not open the following image in a table cell:");
           ffpmsg(extspec);
@@ -1487,7 +1487,7 @@ int fits_already_open(fitsfile **fptr, /* I/O - FITS file pointer       */
        where a file is already opened but it is not realized because it
        was opened with another file path. For instance, if the CWD is
        /a/b/c and I open /a/b/c/foo.fits then open ./foo.fits the previous
-       version of this function would not have reconized that the two files
+       version of this function would not have recognized that the two files
        were the same. This version does recognize that the two files are
        the same.
      */
@@ -1734,7 +1734,7 @@ static int find_quote(char **string)
            tstr++;
         }
     }
-    return(1);  /* opps, didn't find the closing character */
+    return(1);  /* oops, didn't find the closing character */
 }
 /*--------------------------------------------------------------------------*/
 static int find_doublequote(char **string)
@@ -1755,7 +1755,7 @@ static int find_doublequote(char **string)
            tstr++;
         }
     }
-    return(1);  /* opps, didn't find the closing character */
+    return(1);  /* oops, didn't find the closing character */
 }
 
 /*--------------------------------------------------------------------------*/
@@ -1793,7 +1793,7 @@ static int find_paren(char **string)
            tstr++;
         }
     }
-    return(1);  /* opps, didn't find the closing character */
+    return(1);  /* oops, didn't find the closing character */
 }
 /*--------------------------------------------------------------------------*/
 static int find_bracket(char **string)
@@ -1829,7 +1829,7 @@ static int find_bracket(char **string)
            tstr++;
         }
     }
-    return(1);  /* opps, didn't find the closing character */
+    return(1);  /* oops, didn't find the closing character */
 }
 /*--------------------------------------------------------------------------*/
 static int find_curlybracket(char **string)
@@ -1865,7 +1865,7 @@ static int find_curlybracket(char **string)
            tstr++;
         }
     }
-    return(1);  /* opps, didn't find the closing character */
+    return(1);  /* oops, didn't find the closing character */
 }
 /*--------------------------------------------------------------------------*/
 int comma2semicolon(char *string)
@@ -2006,7 +2006,7 @@ int ffedit_columns(
     /* This was done because users cannot enter the semi-colon in the HEASARC's */
     /* Hera on-line data processing system for computer security reasons.  */
     /* Therefore, we must convert those commas back to semi-colons here, but we */
-    /* must not convert any columns that occur within parenthesies.  */
+    /* must not convert any columns that occur within parentheses.  */
 
     if (comma2semicolon(cptr)) {
          ffpmsg("parsing error in column filter expression");
@@ -2212,7 +2212,7 @@ int ffedit_columns(
 		    ffpmsg("The keyword name:");
 		    ffpmsg(colname);
 		    ffpmsg("is invalid unless a column has been previously");
-		    ffpmsg("created or editted by a calculator command");
+		    ffpmsg("created or edited by a calculator command");
                     if( file_expr ) free( file_expr );
 		    if (clause) free(clause);
 		    return(*status = URL_PARSE_ERROR);
@@ -2230,7 +2230,7 @@ int ffedit_columns(
 		      a) colnum is defined, and
 		      b) a column with literal name "NAME#" does not exist, and
 		      c) a keyword with name "NAMEn" (where n=colnum) exists, then
-		    transfrom the colname string to "NAMEn", otherwise
+		    transform the colname string to "NAMEn", otherwise
 		    do nothing.
 		*/
 		if (colnum > 0) {  /* colnum must be defined */
@@ -2260,7 +2260,7 @@ int ffedit_columns(
 	    }
 
             /* if we encountered an opening parenthesis, then we need to */
-            /* find the closing parenthesis, and concatinate the 2 strings */
+            /* find the closing parenthesis, and concatenate the 2 strings */
             /* This supports expressions like:
                 [col #EXTNAME(Extension name)="GTI"]
             */
@@ -5525,7 +5525,7 @@ int ffifile2(char *url,       /* input filename */
        as part of CFITSIO's Extended File Name Syntax.  Test for this
        case by seeing if the last character is a ']' or ')'.  If it 
        is not, then just treat the whole input string as the file name
-       and do not attempt to interprete the name using the extended
+       and do not attempt to interpret the name using the extended
        filename syntax.
      ----------------------------------------------------------- */
 
@@ -5673,7 +5673,7 @@ int ffifile2(char *url,       /* input filename */
 
     /* --------------------------------------------- */
     /* check if the 'filename+n' convention has been */
-    /* used to specifiy which HDU number to open     */ 
+    /* used to specify which HDU number to open     */ 
     /* --------------------------------------------- */
 
     jj = strlen(infile);
@@ -6606,7 +6606,7 @@ int ffrtnm(char *url,
 
     /* --------------------------------------------- */
     /* check if the 'filename+n' convention has been */
-    /* used to specifiy which HDU number to open     */ 
+    /* used to specify which HDU number to open     */ 
     /* --------------------------------------------- */
 
     jj = strlen(infile);
@@ -6891,7 +6891,7 @@ int ffexts(char *extspec,
            /* optional EXTVERS and XTENSION  values */
 
            /* don't use space char as end indicator, because there */
-           /* may be imbedded spaces in the EXTNAME value */
+           /* may be embedded spaces in the EXTNAME value */
            slen = strcspn(ptr1, ",:;");   /* length of EXTNAME */
 
 	   if (slen > FLEN_VALUE - 1)

--- a/cfortran.h
+++ b/cfortran.h
@@ -296,7 +296,7 @@ only C calling FORTRAN subroutines will work using K&R style.*/
      /* BUT we usually use UN for C macro to FORTRAN routines, so use LN here,*/
      /* because VAX/VMS doesn't do recursive macros.                          */
 #define orig_fcallsc(UN,LN)    UN
-#else      /* HP-UX without +ppu or IBMR2 without -qextname. NOT reccomended. */
+#else      /* HP-UX without +ppu or IBMR2 without -qextname. NOT recommended. */
 #define CFC_(UN,LN)            LN           /* Lowercase FORTRAN symbols.     */
 #define orig_fcallsc(UN,LN)    CFC_(UN,LN)
 #endif /*  vmsFortran */

--- a/cookbook.c
+++ b/cookbook.c
@@ -313,7 +313,7 @@ void selectrows( void )
         printf("Error: expected to find a binary table in this HDU\n");
         return;
     }
-    /* move to the last (2rd) HDU in the output file */
+    /* move to the last (2nd) HDU in the output file */
     if ( fits_movabs_hdu(outfptr, 2, &hdutype, &status) )
          printerror( status );
 

--- a/drvrfile.c
+++ b/drvrfile.c
@@ -488,7 +488,7 @@ int file_size(int handle, LONGLONG *filesize)
 /* call the VISUAL C++ version of the routines which support */
 /*  Large Files (> 2GB) if they are supported (since VC 8.0)  */
 
-    position1 = _ftelli64(diskfile);   /* save current postion */
+    position1 = _ftelli64(diskfile);   /* save current position */
     if (position1 < 0)
         return(SEEK_ERROR);
 
@@ -507,7 +507,7 @@ int file_size(int handle, LONGLONG *filesize)
 /* call the newer ftello and fseeko routines , which support */
 /*  Large Files (> 2GB) if they are supported.  */
 
-    position1 = ftello(diskfile);   /* save current postion */
+    position1 = ftello(diskfile);   /* save current position */
     if (position1 < 0)
         return(SEEK_ERROR);
 
@@ -523,7 +523,7 @@ int file_size(int handle, LONGLONG *filesize)
 
 #else
 
-    position1 = ftell(diskfile);   /* save current postion */
+    position1 = ftell(diskfile);   /* save current position */
     if (position1 < 0)
         return(SEEK_ERROR);
 

--- a/drvrgsiftp.c
+++ b/drvrgsiftp.c
@@ -525,7 +525,7 @@ static void signal_handler(int sig) {
     longjmp(env,sig);
     
   default: {
-      /* Hmm, shouldn't have happend */
+      /* Hmm, shouldn't have happened */
       exit(sig);
     }
   }

--- a/drvrmem.c
+++ b/drvrmem.c
@@ -13,7 +13,7 @@
 #include "bzlib.h"
 #endif
 
-/* prototype for .Z file uncompression function in zuncompress.c */
+/* prototype for .Z file decompression function in zuncompress.c */
 int zuncompress2mem(char *filename, 
              FILE *diskfile, 
              char **buffptr, 
@@ -23,7 +23,7 @@ int zuncompress2mem(char *filename,
              int *status);
 
 #if HAVE_BZIP2
-/* prototype for .bz2 uncompression function (in this file) */
+/* prototype for .bz2 decompression function (in this file) */
 void bzip2uncompress2mem(char *filename, FILE *diskfile, int hdl,
                          size_t* filesize, int* status);
 #endif
@@ -198,7 +198,7 @@ int mem_openmem(void **buffptr,   /* I - address of memory pointer          */
     if (*handle == -1)
        return(TOO_MANY_FILES);    /* too many files opened */
 
-    memTable[ii].memaddrptr = (char **) buffptr; /* pointer to start addres */
+    memTable[ii].memaddrptr = (char **) buffptr; /* pointer to start address */
     memTable[ii].memsizeptr = buffsize;     /* allocated size of memory */
     memTable[ii].deltasize = deltasize;     /* suggested realloc increment */
     memTable[ii].fitsfilesize = *buffsize;  /* size of FITS file (upper limit) */
@@ -622,7 +622,7 @@ int mem_compress_open(char *filename, int rwmode, int *hdl)
   But one must allow for the case of very small files, where the
   gzipped file may actually be larger then the original uncompressed file.
   Therefore, only perform the modulo 2^32 correction test if the compressed 
-  file is greater than 10,000 bytes in size.  (Note: this threhold would
+  file is greater than 10,000 bytes in size.  (Note: this threshold would
   fail only if the original file was greater than 2^32 bytes in size AND gzip 
   was able to compress it by more than a factor of 400,000 (!) which seems
   highly unlikely.)
@@ -791,7 +791,7 @@ int mem_compress_stdin_open(char *filename, int rwmode, int *hdl)
 int mem_iraf_open(char *filename, int rwmode, int *hdl)
 /*
   This routine creates an empty memory buffer, then calls iraf2mem to
-  open the IRAF disk file and convert it to a FITS file in memeory.
+  open the IRAF disk file and convert it to a FITS file in memory.
 */
 {
     int status;
@@ -967,7 +967,7 @@ int mem_rawfile_open(char *filename, int rwmode, int *hdl)
         return(status);
     }
 
-    /* create a memory file with corrct size for the FITS converted raw file */
+    /* create a memory file with correct size for the FITS converted raw file */
     status = mem_createmem(filesize, hdl);
     if (status)
     {

--- a/drvrnet.c
+++ b/drvrnet.c
@@ -9,7 +9,7 @@
 
 /* Notes on the drivers:
 
-   The ftp driver uses passive mode exclusivly.  If your remote system can't 
+   The ftp driver uses passive mode exclusively.  If your remote system can't 
    deal with passive mode then it'll fail.  Since Netscape Navigator uses 
    passive mode as well there shouldn't be too many ftp servers which have
    problems.
@@ -32,7 +32,7 @@
    </BODY></HTML>
 
    This redirect was from apache 1.2.5 but most of the other servers produce 
-   something very similiar.  The parser for the redirects finds the first 
+   something very similar.  The parser for the redirects finds the first 
    anchor <A> tag in the body and goes there.  If that wasn't what was intended
    by the remote system then hopefully the error stack, which includes notes 
    about the redirect will help the user fix the problem.
@@ -48,11 +48,11 @@
   ****************************************************************
 
 
-   Root protocal doesn't have any real docs, so, the emperical docs are as 
+   Root protocol doesn't have any real docs, so, the empirical docs are as 
    follows.  
 
    First, you must use a slightly modified rootd server.  The modifications 
-   include implimentation of the stat command which returns the size of the 
+   include implementation of the stat command which returns the size of the 
    remote file.  Without that it's impossible for cfitsio to work properly
    since fitsfiles don't include any information about the size of the files 
    in the headers.  The rootd server closes the connections on any errors, 
@@ -64,7 +64,7 @@
 
    <len><opcode><optional information>
 
-   All binary information is transfered in network format, so use htonl and 
+   All binary information is transferred in network format, so use htonl and 
    ntohl to convert back and forth.
 
    <len> :== 4 byte length, in network format, the len doesn't include the
@@ -119,7 +119,7 @@
 
    ROOTD_PUT - on send <optional info> includes a text message of
    offset and length to put.  Then send the raw bytes you want to
-   write.  Then recieve a status message
+   write.  Then receive a status message
 
 
    When you are finished then you send the message:
@@ -309,7 +309,7 @@ int http_open(char *filename, int rwmode, int *handle)
     ffpmsg("Timeout (http_open)");
     snprintf(errorstr, MAXLEN, "Download timeout exceeded: %d seconds",net_timeout);
     ffpmsg(errorstr);
-    ffpmsg("   (multiplied x10 for files requiring uncompression)");
+    ffpmsg("   (multiplied x10 for files requiring decompression)");
     ffpmsg("   Timeout may be adjusted with fits_set_timeout");
     goto error;
   }
@@ -349,8 +349,8 @@ int http_open(char *filename, int rwmode, int *handle)
     /* Using the cfitsio routine */
 
     status = 0;
-    /* Ok, this is a tough case, let's be arbritary and say 10*net_timeout,
-       Given the choices for nettimeout above they'll probaby ^C before, but
+    /* Ok, this is a tough case, let's be arbitrary and say 10*net_timeout,
+       Given the choices for nettimeout above they'll probably ^C before, but
        it's always worth a shot*/
     
     alarm(net_timeout*10);
@@ -535,7 +535,7 @@ int http_compress_open(char *url, int rwmode, int *handle)
     }
       
   } else {
-    /* Opps, this should not have happened */
+    /* Oops, this should not have happened */
     ffpmsg("Can only have compressed files here (http_compress_open)");
     goto error;
   }    
@@ -604,7 +604,7 @@ int http_file_open(char *url, int rwmode, int *handle)
     ffpmsg("Timeout (http_open)");
     snprintf(errorstr, MAXLEN, "Download timeout exceeded: %d seconds",net_timeout);
     ffpmsg(errorstr);
-    ffpmsg("   (multiplied x10 for files requiring uncompression)");
+    ffpmsg("   (multiplied x10 for files requiring decompression)");
     ffpmsg("   Timeout may be adjusted with fits_set_timeout");
     goto error;
   }
@@ -657,8 +657,8 @@ int http_file_open(char *url, int rwmode, int *handle)
     closeoutfile++;
     status = 0;
 
-    /* Ok, this is a tough case, let's be arbritary and say 10*net_timeout,
-       Given the choices for nettimeout above they'll probaby ^C before, but
+    /* Ok, this is a tough case, let's be arbitrary and say 10*net_timeout,
+       Given the choices for nettimeout above they'll probably ^C before, but
        it's always worth a shot*/
 
     alarm(net_timeout*10);
@@ -990,11 +990,11 @@ static int http_open_network(char *url, FILE **httpfile, char *contentencoding,
 	}
       }
 
-      /* if we get here then we couldnt' decide the redirect */
+      /* if we get here then we couldn't decide the redirect */
       ffpmsg("but we were unable to find the redirected url in the servers response");
     }
 
-    /* error.  could not open the http file */
+    /* error. couldn't open the http file */
     fclose(*httpfile);
     *httpfile=0;
     return (FILE_NOT_OPENED);
@@ -1038,7 +1038,7 @@ static int http_open_network(char *url, FILE **httpfile, char *contentencoding,
 
 /*--------------------------------------------------------------------------*/
 /* This creates a memory file handle with a copy of the URL in filename. The 
-   curl library called from https_open_network will perform file uncompression
+   curl library called from https_open_network will perform file decompression
    if necessary. */
 int https_open(char *filename, int rwmode, int *handle)
 {
@@ -1080,7 +1080,7 @@ int https_open(char *filename, int rwmode, int *handle)
   }
   alarm(0);
   signal(SIGALRM, SIG_DFL);
-  /* We now have the file transfered from the https server into the
+  /* We now have the file transferred from the https server into the
      inmem.memory buffer.  Now transfer that into a FITS memory file. */
   if ((status = mem_create(filename, handle)))
   {
@@ -1376,7 +1376,7 @@ int ftps_open(char *filename, int rwmode, int *handle)
      strcpy(filename, localFilename);
   }
   
-  /* We now have the file transfered from the ftps server into the
+  /* We now have the file transferred from the ftps server into the
      inmem.memory buffer.  Now transfer that into a FITS memory file. */
   if ((status = mem_create(filename, handle)))
   {
@@ -1884,7 +1884,7 @@ int ssl_get_with_curl(char *url, curlmembuf* buffer, char* username,
   /* This turns on automatic decompression for all recognized types. */
   curl_easy_setopt(curl, CURLOPT_ENCODING, "");
   
-  /* tmpUrl should be large enough to accomodate original url + ".gz" */
+  /* tmpUrl should be large enough to accommodate original url + ".gz" */
   tmpUrl = (char *)malloc(strlen(url)+4);
   strcpy(tmpUrl, url);
   if (show_fits_download_progress)
@@ -2097,14 +2097,14 @@ int ftp_open(char *filename, int rwmode, int *handle)
     ffpmsg("Timeout (ftp_open)");
     snprintf(errorstr, MAXLEN, "Download timeout exceeded: %d seconds",net_timeout);
     ffpmsg(errorstr);
-    ffpmsg("   (multiplied x10 for files requiring uncompression)");
+    ffpmsg("   (multiplied x10 for files requiring decompression)");
     ffpmsg("   Timeout may be adjusted with fits_set_timeout");
     goto error;
   }
 
   signal(SIGALRM, signal_handler);
   
-  /* Open the ftp connetion.  ftpfile is connected to the file port, 
+  /* Open the ftp connection.  ftpfile is connected to the file port, 
      command is connected to port 21.  sock is the socket on port 21 */
 
   if (strlen(filename) > MAXLEN - 4) {
@@ -2144,7 +2144,7 @@ int ftp_open(char *filename, int rwmode, int *handle)
       ('\037' == firstchar)) {
     
     status = 0;
-    /* A bit arbritary really, the user will probably hit ^C */
+    /* A bit arbitrary really, the user will probably hit ^C */
     alarm(net_timeout*10);
     status = mem_uncompress2mem(filename, ftpfile, *handle);
     alarm(0);
@@ -2239,7 +2239,7 @@ int ftp_file_open(char *url, int rwmode, int *handle)
     ffpmsg("Timeout (ftp_file_open)");
     snprintf(errorstr, MAXLEN, "Download timeout exceeded: %d seconds",net_timeout);
     ffpmsg(errorstr);
-    ffpmsg("   (multiplied x10 for files requiring uncompression)");
+    ffpmsg("   (multiplied x10 for files requiring decompression)");
     ffpmsg("   Timeout may be adjusted with fits_set_timeout");
     goto error;
   }
@@ -2295,8 +2295,8 @@ int ftp_file_open(char *url, int rwmode, int *handle)
     closeoutfile++;
     status = 0;
 
-    /* Ok, this is a tough case, let's be arbritary and say 10*net_timeout,
-       Given the choices for nettimeout above they'll probaby ^C before, but
+    /* Ok, this is a tough case, let's be arbitrary and say 10*net_timeout,
+       Given the choices for nettimeout above they'll probably ^C before, but
        it's always worth a shot*/
 
     alarm(net_timeout*10);
@@ -2505,7 +2505,7 @@ int ftp_compress_open(char *url, int rwmode, int *handle)
     }
       
   } else {
-    /* Opps, this should not have happened */
+    /* Oops, this should not have happened */
     ffpmsg("Can only compressed files here (ftp_compress_open)");
     goto error;
   }    
@@ -3402,7 +3402,7 @@ int http_checkfile (char *urltype, char *infile, char *outfile1)
 
   if (!strstr(infile,".gz") && (!strstr(infile,".Z"))) {
     /* The infile string does not contain the name of a compressed file.  */
-    /* Fisrt, look for a .gz compressed version of the file. */
+    /* First, look for a .gz compressed version of the file. */
     
     if (strlen(infile) + 3 > MAXLEN-1)
     {
@@ -3471,7 +3471,7 @@ int http_checkfile (char *urltype, char *infile, char *outfile1)
     }
     else if (status != FILE_NOT_OPENED)
     {
-       /* Some other error occured aside from not finding file, such as
+       /* Some other error occurred aside from not finding file, such as
           a url parsing error.  Don't continue trying with other extensions. */
        return status;   
     }
@@ -3708,7 +3708,7 @@ int ftp_checkfile (char *urltype, char *infile, char *outfile1)
 
  if (!strstr(infile,".gz") && (!strstr(infile,".Z"))) {
     /* The infile string does not contain the name of a compressed file.  */
-    /* Fisrt, look for a .gz compressed version of the file. */
+    /* First, look for a .gz compressed version of the file. */
       
     if (strlen(infile)+3 > MAXLEN-1)
     {
@@ -3808,7 +3808,7 @@ int ftp_checkfile (char *urltype, char *infile, char *outfile1)
 }
 /*--------------------------------------------------------------------------*/
 /* A small helper function to wait for a particular status on the ftp 
-   connectino */
+   connection */
 static int ftp_status(FILE *ftp, char *statusstr)
 {
   /* read through until we find a string beginning with statusstr */
@@ -3922,7 +3922,7 @@ static void signal_handler(int sig) {
     longjmp(env,sig);
     
   default: {
-      /* Hmm, shouldn't have happend */
+      /* Hmm, shouldn't have happened */
       exit(sig);
     }
   }
@@ -4359,7 +4359,7 @@ static int root_recv_buffer(int sock, int *op, char *buffer, int buflen)
 
   len = ntohl(len);
 
-  /* ok, have the length, recive the operation */
+  /* ok, have the length, receive the operation */
   len -= 4;
   status = NET_RecvRaw(sock,op,4);
   if (status < 0) {

--- a/drvrsmem.c
+++ b/drvrsmem.c
@@ -412,13 +412,13 @@ int     shared_malloc(long size, int mode, int newhandle)               /* retur
       if (shared_debug) printf(" key=%d", key);
       h = shmget(key, shared_adjust_size(size), IPC_CREAT | IPC_EXCL | shared_create_mode);
       if (shared_debug) printf(" handle=%d", h);
-      if (SHARED_INVALID == h) continue;                /* segment already accupied */
+      if (SHARED_INVALID == h) continue;                /* segment already occupied */
       bp = (BLKHEAD *)shmat(h, 0, 0);                   /* try attach */
       if (shared_debug) printf(" p=%p", bp);
       if (((BLKHEAD *)SHARED_INVALID) == bp)            /* cannot attach, delete segment, try with another key */
         { shmctl(h, IPC_RMID, 0);
           continue;
-        }                                               /* now create semaphor counting number of processes attached */
+        }                                               /* now create semaphore counting number of processes attached */
       if (SHARED_INVALID == (shared_gt[idx].sem = semget(key, 1, IPC_CREAT | IPC_EXCL | shared_create_mode)))
         { shmdt((void *)bp);                            /* cannot create segment, delete everything */
           shmctl(h, IPC_RMID, 0);
@@ -559,7 +559,7 @@ SHARED_P shared_realloc(int idx, long newsize)  /* realloc shared memory segment
     { if (i >= shared_range)  return(NULL);     /* table full, signal error & exit */
       key = shared_kbase + ((i + shared_get_hash(newsize, idx)) % shared_range);
       h = shmget(key, shared_adjust_size(newsize), IPC_CREAT | IPC_EXCL | shared_create_mode);
-      if (SHARED_INVALID == h) continue;        /* segment already accupied */
+      if (SHARED_INVALID == h) continue;        /* segment already occupied */
       bp = (BLKHEAD *)shmat(h, 0, 0);           /* try attach */
       if (((BLKHEAD *)SHARED_INVALID) == bp)    /* cannot attach, delete segment, try with another key */
         { shmctl(h, IPC_RMID, 0);

--- a/drvrsmem.h
+++ b/drvrsmem.h
@@ -22,7 +22,7 @@
 
 #define	SHARED_MAXSEG	(16)		/* maximum number of shared memory blocks */
 
-#define	SHARED_KEYBASE	(14011963)	/* base for shared memory keys, may be overriden by getenv */
+#define	SHARED_KEYBASE	(14011963)	/* base for shared memory keys, may be overridden by getenv */
 #define	SHARED_FDNAME	("/tmp/.shmem-lockfile") /* template for lock file name */
 
 #define	SHARED_ENV_KEYBASE ("SHMEM_LIB_KEYBASE") /* name of environment variable */

--- a/editcol.c
+++ b/editcol.c
@@ -210,7 +210,7 @@ int ffirow(fitsfile *fptr,  /* I - FITS file pointer                        */
            LONGLONG nrows,      /* I - number of rows to insert                 */
            int *status)     /* IO - error status                            */
 /*
- insert NROWS blank rows immediated after row firstrow (1 = first row).
+ insert NROWS blank rows immediately after row firstrow (1 = first row).
  Set firstrow = 0 to insert space at the beginning of the table.
 */
 {
@@ -2281,7 +2281,7 @@ int ffcprw(fitsfile *infptr,    /* I - FITS file pointer to input file  */
 		{
 		   if (nVarBytes > nVarAllocBytes)
 		   {
-		     /* Grow the copy buffer to accomodate the new maximum size. 
+		     /* Grow the copy buffer to accommodate the new maximum size. 
 			Note it is safe to call realloc() with null input pointer, 
 			which is equivalent to malloc(). */
 		     unsigned char *varColBuff1 = (unsigned char *) realloc(varColBuff, nVarBytes);
@@ -2744,7 +2744,7 @@ int ffkshf(fitsfile *fptr,  /* I - FITS file pointer                        */
   and has an index number in the range COLMIN - COLMAX, inclusive.
 
   if incre is positive, then the index values will be incremented.
-  if incre is negative, then the kewords with index = COLMIN
+  if incre is negative, then the keywords with index = COLMIN
   will be deleted and the index of higher numbered keywords will
   be decremented.
 */

--- a/eval_f.c
+++ b/eval_f.c
@@ -130,7 +130,7 @@ int fffrow( fitsfile *fptr,         /* I - Input FITS file                   */
 
       if( ffiter( gParse.nCols, gParse.colData, firstrow-1, 0,
                   parse_data, (void*)&Info, status ) == -1 )
-         *status = 0;  /* -1 indicates exitted without error before end... OK */
+         *status = 0;  /* -1 indicates exited without error before end... OK */
 
       if( *status ) {
 
@@ -468,7 +468,7 @@ int ffcrow( fitsfile *fptr,      /* I - Input FITS file                      */
    
    if( ffiter( gParse.nCols, gParse.colData, firstrow-1, 0,
                parse_data, (void*)&Info, status ) == -1 )
-      *status=0;  /* -1 indicates exitted without error before end... OK */
+      *status=0;  /* -1 indicates exited without error before end... OK */
 
    *anynul = Info.anyNull;
    ffcprs();
@@ -882,7 +882,7 @@ int ffiprs( fitsfile *fptr,      /* I - Input FITS file                     */
    gParse.index    = 0;
    gParse.is_eobuf = 0;
 
-   /*  Parse the expression, building the Nodes and determing  */
+   /*  Parse the expression, building the Nodes and determining  */
    /*  which columns are needed and what data type is returned  */
 
    ffrestart(NULL);
@@ -2006,7 +2006,7 @@ int uncompress_hkdata( fitsfile *fptr,
       if( ffgcvd( fptr, gParse.timeCol, row, 1L, 1L, 0.0,
                   &newtime, &anynul, status ) ) return( *status );
       if( newtime != currtime ) {
-         /*  New time encountered... propogate parameters to next row  */
+         /*  New time encountered... propagate parameters to next row  */
          if( currelem==ntimes ) {
             ffpmsg("Found more unique time stamps than caller indicated");
             return( *status = PARSE_BAD_COL );
@@ -2128,7 +2128,7 @@ int ffffrw( fitsfile *fptr,         /* I - Input FITS file                   */
    } else {
       if( ffiter( gParse.nCols, gParse.colData, 0, 0,
                   ffffrw_work, (void*)rownum, status ) == -1 )
-         *status = 0;  /* -1 indicates exitted without error before end... OK */
+         *status = 0;  /* -1 indicates exited without error before end... OK */
    }
 
    ffcprs();

--- a/f77_wrap.h
+++ b/f77_wrap.h
@@ -158,7 +158,7 @@ static char *f2cstrv2(char *fstr, char* cstr, int felem_len, int celem_len,
 
 /************************************************************************
    The following definitions redefine the BYTE data type to be
-   interpretted as a character*1 string instead of an integer*1 which
+   interpreted as a character*1 string instead of an integer*1 which
    is not supported by all compilers.
 *************************************************************************/
 

--- a/f77_wrap4.c
+++ b/f77_wrap4.c
@@ -52,7 +52,7 @@ typedef struct {
    void (*Fwork_fn)(PLONG_cfTYPE *total_n, ...);
 } FtnUserData;
 
-/*        Declare protoypes to make C++ happy       */
+/*        Declare prototypes to make C++ happy       */
 int Cwork_fn(long, long, long, long, int, iteratorCol *, void *);
 void Cffiter( int n_cols, int *units, int *colnum, char *colname[], 
 	      int *datatype, int *iotype,

--- a/fits_hcompress.c
+++ b/fits_hcompress.c
@@ -3,7 +3,7 @@ These routines to apply the H-compress compression algorithm to a 2-D Fits
 image were written by R. White at the STScI and were obtained from the STScI at
 http://www.stsci.edu/software/hcompress.html
 
-This source file is a concatination of the following sources files in the
+This source file is a concatenation of the following sources files in the
 original distribution 
  htrans.c 
  digitize.c 
@@ -21,7 +21,7 @@ The following modifications have been made to the original code:
     the same source file
   - changed the first parameter in encode (and in lower level routines from a file stream
     to a char array
-  - modifid the encode routine to return the size of the compressed array of bytes
+  - modified the encode routine to return the size of the compressed array of bytes
   - changed calls to printf and perror to call the CFITSIO ffpmsg routine
   - modified the mywrite routine, and lower level byte writing routines,  to copy 
     the output bytes to a char array, instead of writing them to a file stream
@@ -1190,7 +1190,7 @@ if (bits_to_go2 != 8)
 	
 	if (bits_to_go2 == 8) {
 	    /* special case if nybbles are aligned on byte boundary */
-	    /* this actually seems to make very little differnece in speed */
+	    /* this actually seems to make very little difference in speed */
 	    buffer2 = 0;
 	    for (ii = 0; ii < jj; ii++)
 	    {

--- a/fits_hdecompress.c
+++ b/fits_hdecompress.c
@@ -3,7 +3,7 @@ These routines to apply the H-compress decompression algorithm to a 2-D Fits
 image were written by R. White at the STScI and were obtained from the STScI at
 http://www.stsci.edu/software/hcompress.html
 
-This source file is a concatination of the following sources files in the
+This source file is a concatenation of the following sources files in the
 original distribution 
   hinv.c 
   hsmooth.c 
@@ -67,7 +67,7 @@ static int qtree_decode64(unsigned char *infile, LONGLONG a[], int n, int nqx, i
 static void start_inputing_bits(void);
 static int input_bit(unsigned char *infile);
 static int input_nbits(unsigned char *infile, int n);
-/*  make input_nybble a separate routine, for added effiency */
+/*  make input_nybble a separate routine, for added efficiency */
 /* #define input_nybble(infile)	input_nbits(infile,4) */
 static int input_nybble(unsigned char *infile);
 static int input_nnybble(unsigned char *infile, int n, unsigned char *array);
@@ -2502,7 +2502,7 @@ static int input_bit(unsigned char *infile)
 
 static int input_nbits(unsigned char *infile, int n)
 {
-    /* AND mask for retreiving the right-most n bits */
+    /* AND mask for retrieving the right-most n bits */
     static int mask[9] = {0, 1, 3, 7, 15, 31, 63, 127, 255};
 
 	if (bits_to_go < n) {

--- a/fitscopy.c
+++ b/fitscopy.c
@@ -54,7 +54,7 @@ int main(int argc, char *argv[])
       fits_close_file(infptr, &status);
     }
 
-    /* if error occured, print out error message */
+    /* if error occurred, print out error message */
     if (status) fits_report_error(stderr, status);
     return(status);
 }

--- a/fitscore.c
+++ b/fitscore.c
@@ -537,7 +537,7 @@ void ffgerr(int status,     /* I - error status value */
        strcpy(errtext, "too many HDUs tracked");
        break;
     case 346:
-       strcpy(errtext, "HDU alread tracked");
+       strcpy(errtext, "HDU already tracked");
        break;
     case 347:
        strcpy(errtext, "bad Grouping option");
@@ -1592,7 +1592,7 @@ int ffgthd(char *tmplt, /* I - input header template string */
            int *status)   /* IO - error status   */
 /*
   'Get Template HeaDer'
-  parse a template header line and create a formated
+  parse a template header line and create a formatted
   character string which is suitable for appending to a FITS header 
 */
 {
@@ -2003,7 +2003,7 @@ then values of 'n' less than or equal to n_value will match.
       /* 
 	 ip = index of pattern character being matched
 	 ic = index of keyname character being matched
-	 firstfail = 1 if we fail on the first characteor (0=not)
+	 firstfail = 1 if we fail on the first character (0=not)
       */
       
       for (ip=0, ic=0, firstfail=1;
@@ -2495,7 +2495,7 @@ then values of 'n' less than or equal to n_value will match.
       /* 
 	 ip = index of pattern character being matched
 	 ic = index of keyname character being matched
-	 firstfail = 1 if we fail on the first characteor (0=not)
+	 firstfail = 1 if we fail on the first character (0=not)
       */
       
       for (ip=0, ic=0, firstfail=1;
@@ -2768,7 +2768,7 @@ int ffasfm(char *tform,    /* I - format code from the TFORMn keyword */
                 if (ffc2ii(form, &longval, status) <= 0) /* read decimals */
                 {
                     if (decimals)
-                        *decimals = longval;  /* long to short convertion */
+                        *decimals = longval;  /* long to short conversion */
 
                     if (longval >= width)  /* width < no. of decimals */
                         *status = BAD_TFORM; 
@@ -3287,7 +3287,7 @@ void ffcdsp(char *tform,    /* value of an ASCII table TFORMn keyword */
     return;
 }
 /*--------------------------------------------------------------------------*/
-int ffgcno( fitsfile *fptr,  /* I - FITS file pionter                       */
+int ffgcno( fitsfile *fptr,  /* I - FITS file pointer                       */
             int  casesen,    /* I - case sensitive string comparison? 0=no  */
             char *templt,    /* I - input name of column (w/wildcards)      */
             int  *colnum,    /* O - number of the named column; 1=first col */
@@ -3450,7 +3450,7 @@ void ffcmps(char *templt,   /* I - input template (may have wildcards)      */
   This algorithm is very similar to the way unix filename wildcards
   work except that this first treats a wild card as a literal character
   when looking for a match.  If there is no literal match, then
-  it interpretes it as a wild card.  So the template 'AB*DE'
+  it interprets it as a wild card.  So the template 'AB*DE'
   is considered to be an exact rather than a wild card match to
   the string 'AB*DE'.  The '#' wild card in the template string will 
   match any consecutive string of decimal digits in the colname.
@@ -5640,7 +5640,7 @@ int ffgcprll( fitsfile *fptr, /* I - FITS file pointer                      */
       rangecheck = 0;
     }
 
-    /* Special case: interprete 'X' column as 'B' */
+    /* Special case: interpret 'X' column as 'B' */
     if (abs(*tcode) == TBIT)
     {
         *tcode  = *tcode / TBIT * TBYTE;
@@ -5662,7 +5662,7 @@ int ffgcprll( fitsfile *fptr, /* I - FITS file pointer                      */
     else
         *elemnum = firstelem - 1;
 
-    /* interprete complex and double complex as pairs of floats or doubles */
+    /* interpret complex and double complex as pairs of floats or doubles */
     if (abs(*tcode) >= TCOMPLEX)
     {
         if (*tcode > 0)
@@ -6181,11 +6181,11 @@ int ffcmph(fitsfile *fptr,  /* I -FITS file pointer                         */
               }
             }
 
-            /* read arrray of bytes from temporary copy */
+            /* read array of bytes from temporary copy */
             ffmbyt(tptr, readheapstart + offset, REPORT_EOF, status);
             ffgbyt(tptr, nbytes, buffer, status);
 
-            /* write arrray of bytes back to original file */
+            /* write array of bytes back to original file */
             ffmbyt(fptr, writeheapstart + (fptr->Fptr)->heapsize, 
                     IGNORE_EOF, status);
             ffpbyt(fptr, nbytes, buffer, status);
@@ -6923,7 +6923,7 @@ int ffwend(fitsfile *fptr,       /* I - FITS file pointer */
     The END keyword must either be placed immediately after the last
     keyword that was written (as indicated by the headend value), or
     must be in the first 80 bytes of the 2880-byte FITS record immediately 
-    preceeding the data unit, whichever is further in the file. The
+    preceding the data unit, whichever is further in the file. The
     latter will occur if space has been reserved for more header keywords
     which have not yet been written.
     */
@@ -7292,7 +7292,7 @@ int ffghdt(fitsfile *fptr,      /* I - FITS file pointer             */
         return(*status);
 
     if (fptr->HDUposition == 0 && (fptr->Fptr)->headend == 0) { 
-         /* empty primary array is alway an IMAGE_HDU */
+         /* empty primary array is always an IMAGE_HDU */
          *exttype = IMAGE_HDU;
     }
     else {
@@ -7843,7 +7843,7 @@ int ffmnhd(fitsfile *fptr,      /* I - FITS file pointer                    */
        Setting putback = 1 means that we need to test for this case later on.
     */
         
-    if ((fptr->Fptr)->only_one) {  /* if true, name orignally ended with a # */
+    if ((fptr->Fptr)->only_one) {  /* if true, name originally ended with a # */
        slen = strlen(hduname);
        if (hduname[slen - 1] != '#') /* This will fail if real EXTNAME value */
            putback = 1;              /*  ends with 2 # characters. */
@@ -8118,7 +8118,7 @@ int ffiblk(fitsfile *fptr,      /* I - FITS file pointer               */
 
             ffgbyt(fptr, 2880, inbuff,status);  /* read one record */
 
-            /* move forward to the write postion */
+            /* move forward to the write position */
             ffmbyt(fptr, jpoint + ((LONGLONG) nblock * 2880), IGNORE_EOF, status);
 
             ffpbyt(fptr, 2880, inbuff, status);  /* write the record */
@@ -8126,7 +8126,7 @@ int ffiblk(fitsfile *fptr,      /* I - FITS file pointer               */
             jpoint -= 2880;
         }
 
-        /* move back to the write start postion (might be EOF) */
+        /* move back to the write start position (might be EOF) */
         ffmbyt(fptr, insertpt, IGNORE_EOF, status);
 
         for (ii = 0; ii < nblock; ii++)   /* insert correct fill value */
@@ -8818,7 +8818,7 @@ int ffdtyp(const char *cval,  /* I - formatted string representation of the valu
     else if (cval[0] == '(')
         *dtype = 'X';          /* complex datatype "(1.2, -3.4)" */
     else if (strchr(cval,'.'))
-        *dtype = 'F';          /* float usualy contains a decimal point */
+        *dtype = 'F';          /* float usually contains a decimal point */
     else if (strchr(cval,'E') || strchr(cval,'D') )
         *dtype = 'F';          /* exponential contains a E or D */
     else

--- a/fitsio.h
+++ b/fitsio.h
@@ -159,7 +159,7 @@ SERVICES PROVIDED HEREUNDER."
 #define LONGLONG_MIN LONG_LONG_MIN
 
 #elif defined(__LONG_LONG_MAX__)
-/* Mac OS X & CYGWIN defintion */
+/* Mac OS X & CYGWIN definition */
 #define LONGLONG_MAX __LONG_LONG_MAX__
 #define LONGLONG_MIN (-LONGLONG_MAX -1LL)
 
@@ -374,8 +374,8 @@ typedef struct      /* structure used to store basic FITS file information */
     int maxhdu;       /* highest numbered HDU known to exist in the file */
     int MAXHDU;       /* dynamically allocated dimension of headstart array */
     LONGLONG *headstart; /* byte offset in file to start of each HDU */
-    LONGLONG headend;   /* byte offest in file to end of the current HDU header */
-    LONGLONG ENDpos;    /* byte offest to where the END keyword was last written */
+    LONGLONG headend;   /* byte offset in file to end of the current HDU header */
+    LONGLONG ENDpos;    /* byte offset to where the END keyword was last written */
     LONGLONG nextkey;   /* byte offset in file to beginning of next keyword */
     LONGLONG datastart; /* byte offset in file to start of the current data unit */
     int imgdim;         /* dimension of image; cached for fast access */
@@ -674,10 +674,10 @@ int CFITS_API fits_read_wcstab(fitsfile *fptr, int nwtb, wtbarr *wtb, int *statu
 
 #define BAD_I2C           401  /* bad int to formatted string conversion */
 #define BAD_F2C           402  /* bad float to formatted string conversion */
-#define BAD_INTKEY        403  /* can't interprete keyword value as integer */
-#define BAD_LOGICALKEY    404  /* can't interprete keyword value as logical */
-#define BAD_FLOATKEY      405  /* can't interprete keyword value as float */
-#define BAD_DOUBLEKEY     406  /* can't interprete keyword value as double */
+#define BAD_INTKEY        403  /* can't interpret keyword value as integer */
+#define BAD_LOGICALKEY    404  /* can't interpret keyword value as logical */
+#define BAD_FLOATKEY      405  /* can't interpret keyword value as float */
+#define BAD_DOUBLEKEY     406  /* can't interpret keyword value as double */
 #define BAD_C2I           407  /* bad formatted string to int conversion */
 #define BAD_C2F           408  /* bad formatted string to float conversion */
 #define BAD_C2D           409  /* bad formatted string to double conversion */

--- a/fitsio2.h
+++ b/fitsio2.h
@@ -52,7 +52,7 @@ extern int Fitsio_Pthread_Status;
 
 #define NMAXFILES  10000   /* maximum number of FITS files that can be opened */
         /* CFITSIO will allocate (NMAXFILES * 80) bytes of memory */
-	/* plus each file that is opened will use NIOBUF * 2880 bytes of memeory */
+	/* plus each file that is opened will use NIOBUF * 2880 bytes of memory */
 	/* where NIOBUF is defined in fitio.h and has a default value of 40 */
 
 #define MINDIRECT 8640   /* minimum size for direct reads and writes */

--- a/fpackutil.c
+++ b/fpackutil.c
@@ -126,7 +126,7 @@ int fp_tmpnam(char *suffix, char *rootname, char *tmpnam)
 	int maxtry = 30, ii;
 
 	if (strlen(suffix) + strlen(rootname) > SZ_STR-5) {
-	    fp_msg ("Error: filename is too long to create tempory file\n"); exit (-1);
+	    fp_msg ("Error: filename is too long to create temporary file\n"); exit (-1);
 	}
 
 	strcpy (tmpnam, rootname);  /* start with rootname */
@@ -398,7 +398,7 @@ int fp_preflight (int argc, char *argv[], int unpack, fpstate *fpptr)
 	      /* check that input file  exists */
 	      if (infits[0] != '-') {  /* if not reading from stdin stream */
 	         if (fp_access (infits) != 0) {  /* if not, then check if */
-		    strcat(infits, ".fz");       /* a .fz version exsits */
+		    strcat(infits, ".fz");       /* a .fz version exists */
 	            if (fp_access (infits) != 0) {
                         namelen = strlen(infits);
                         infits[namelen - 3] = '\0';  /* remove the .fz suffix */
@@ -514,7 +514,7 @@ int fp_preflight (int argc, char *argv[], int unpack, fpstate *fpptr)
 		        fp_msg ("Error: input file name too long:\n "); fp_msg (infits);
 		        fp_msg ("\n "); fp_noop (); exit (-1);
                     }
-		    strcat(infits, ".gz");     /* a gzipped version exsits */
+		    strcat(infits, ".gz");     /* a gzipped version exists */
 	            if (fp_access (infits) != 0) {
                         namelen = strlen(infits);
                         infits[namelen - 3] = '\0';  /* remove the .gz suffix */
@@ -668,7 +668,7 @@ int fp_loop (int argc, char *argv[], int unpack, fpstate fpvar)
 	      /* find input file */
 	      if (infits[0] != '-') {  /* if not reading from stdin stream */
 	         if (fp_access (infits) != 0) {  /* if not, then */
-		    strcat(infits, ".fz");       /* a .fz version must exsit */
+		    strcat(infits, ".fz");       /* a .fz version must exist */
                     /* fp_preflight already checked for enough size to add '.fz' */
 	         }
 	      }

--- a/getcolb.c
+++ b/getcolb.c
@@ -260,7 +260,7 @@ int ffgsvb(fitsfile *fptr, /* I - FITS file pointer                         */
 
 /*
     if this is a primary array, then the input COLNUM parameter should
-    be interpreted as the row number, and we will alway read the image
+    be interpreted as the row number, and we will always read the image
     data from column 2 (any group parameters are in column 1).
 */
     if (ffghdt(fptr, &hdutype, status) > 0)
@@ -435,7 +435,7 @@ int ffgsfb(fitsfile *fptr, /* I - FITS file pointer                         */
 
 /*
     if this is a primary array, then the input COLNUM parameter should
-    be interpreted as the row number, and we will alway read the image
+    be interpreted as the row number, and we will always read the image
     data from column 2 (any group parameters are in column 1).
 */
     if (ffghdt(fptr, &hdutype, status) > 0)
@@ -772,7 +772,7 @@ int ffgclb( fitsfile *fptr,   /* I - FITS file pointer                       */
     /*----------------------------------------------------------------------*/
     convert = 1;
     if (tcode == TBYTE) /* Special Case:                        */
-    {                             /* no type convertion required, so read */
+    {                             /* no type conversion required, so read */
                                   /* data directly into output buffer.    */
 
         if (nelem < (LONGLONG)INT32_MAX) {
@@ -789,7 +789,7 @@ int ffgclb( fitsfile *fptr,   /* I - FITS file pointer                       */
     /*  Now read the pixels from the FITS column. If the column does not   */
     /*  have the same datatype as the output array, then we have to read   */
     /*  the raw values into a temporary buffer (of limited size).  In      */
-    /*  the case of a vector colum read only 1 vector of values at a time  */
+    /*  the case of a vector column read only 1 vector of values at a time  */
     /*  then skip to the next row if more values need to be read.          */
     /*  After reading the raw values, then call the fffXXYY routine to (1) */
     /*  test for undefined values, (2) convert the datatype if necessary,  */
@@ -867,7 +867,7 @@ int ffgclb( fitsfile *fptr,   /* I - FITS file pointer                       */
                      ffgbytoff(fptr, twidth, ntodo, incre - twidth, buffer,
                                status);
 
-                /* interpret the string as an ASCII formated number */
+                /* interpret the string as an ASCII formatted number */
                 fffstri1((char *) buffer, ntodo, scale, zero, twidth, power,
                       nulcheck, snull, nulval, &nularray[next], anynul,
                       &array[next], status);
@@ -948,7 +948,7 @@ int ffgextn( fitsfile *fptr,        /* I - FITS file pointer                    
             void *buffer,          /* I - stream of bytes to read                  */
             int  *status)          /* IO - error status                            */
 /*
-  Read a stream of bytes from the current FITS HDU.  This primative routine is mainly
+  Read a stream of bytes from the current FITS HDU.  This primitive routine is mainly
   for reading non-standard "conforming" extensions and should not be used
   for standard IMAGE, TABLE or BINTABLE extensions.
 */

--- a/getcold.c
+++ b/getcold.c
@@ -261,7 +261,7 @@ int ffgsvd(fitsfile *fptr, /* I - FITS file pointer                         */
 
 /*
     if this is a primary array, then the input COLNUM parameter should
-    be interpreted as the row number, and we will alway read the image
+    be interpreted as the row number, and we will always read the image
     data from column 2 (any group parameters are in column 1).
 */
     if (ffghdt(fptr, &hdutype, status) > 0)
@@ -435,7 +435,7 @@ int ffgsfd(fitsfile *fptr, /* I - FITS file pointer                         */
     }
 /*
     if this is a primary array, then the input COLNUM parameter should
-    be interpreted as the row number, and we will alway read the image
+    be interpreted as the row number, and we will always read the image
     data from column 2 (any group parameters are in column 1).
 */
     if (ffghdt(fptr, &hdutype, status) > 0)
@@ -807,7 +807,7 @@ int ffgcld( fitsfile *fptr,   /* I - FITS file pointer                       */
     /*----------------------------------------------------------------------*/
     convert = 1;
     if (tcode == TDOUBLE) /* Special Case:                        */
-    {                              /* no type convertion required, so read */
+    {                              /* no type conversion required, so read */
                                   /* data directly into output buffer.    */
 
         if (nelem < (LONGLONG)INT32_MAX/8) {
@@ -824,7 +824,7 @@ int ffgcld( fitsfile *fptr,   /* I - FITS file pointer                       */
     /*  Now read the pixels from the FITS column. If the column does not   */
     /*  have the same datatype as the output array, then we have to read   */
     /*  the raw values into a temporary buffer (of limited size).  In      */
-    /*  the case of a vector colum read only 1 vector of values at a time  */
+    /*  the case of a vector column read only 1 vector of values at a time  */
     /*  then skip to the next row if more values need to be read.          */
     /*  After reading the raw values, then call the fffXXYY routine to (1) */
     /*  test for undefined values, (2) convert the datatype if necessary,  */

--- a/getcole.c
+++ b/getcole.c
@@ -261,7 +261,7 @@ int ffgsve(fitsfile *fptr, /* I - FITS file pointer                         */
 
 /*
     if this is a primary array, then the input COLNUM parameter should
-    be interpreted as the row number, and we will alway read the image
+    be interpreted as the row number, and we will always read the image
     data from column 2 (any group parameters are in column 1).
 */
     if (ffghdt(fptr, &hdutype, status) > 0)
@@ -436,7 +436,7 @@ int ffgsfe(fitsfile *fptr, /* I - FITS file pointer                         */
 
 /*
     if this is a primary array, then the input COLNUM parameter should
-    be interpreted as the row number, and we will alway read the image
+    be interpreted as the row number, and we will always read the image
     data from column 2 (any group parameters are in column 1).
 */
     if (ffghdt(fptr, &hdutype, status) > 0)
@@ -808,7 +808,7 @@ int ffgcle( fitsfile *fptr,   /* I - FITS file pointer                       */
     /*----------------------------------------------------------------------*/
     convert = 1;
     if (tcode == TFLOAT) /* Special Case:                        */
-    {                             /* no type convertion required, so read */
+    {                             /* no type conversion required, so read */
                                   /* data directly into output buffer.    */
 
         if (nelem < (LONGLONG)INT32_MAX/4) {
@@ -825,7 +825,7 @@ int ffgcle( fitsfile *fptr,   /* I - FITS file pointer                       */
     /*  Now read the pixels from the FITS column. If the column does not   */
     /*  have the same datatype as the output array, then we have to read   */
     /*  the raw values into a temporary buffer (of limited size).  In      */
-    /*  the case of a vector colum read only 1 vector of values at a time  */
+    /*  the case of a vector column read only 1 vector of values at a time  */
     /*  then skip to the next row if more values need to be read.          */
     /*  After reading the raw values, then call the fffXXYY routine to (1) */
     /*  test for undefined values, (2) convert the datatype if necessary,  */

--- a/getcoli.c
+++ b/getcoli.c
@@ -260,7 +260,7 @@ int ffgsvi(fitsfile *fptr, /* I - FITS file pointer                         */
 
 /*
     if this is a primary array, then the input COLNUM parameter should
-    be interpreted as the row number, and we will alway read the image
+    be interpreted as the row number, and we will always read the image
     data from column 2 (any group parameters are in column 1).
 */
     if (ffghdt(fptr, &hdutype, status) > 0)
@@ -435,7 +435,7 @@ int ffgsfi(fitsfile *fptr, /* I - FITS file pointer                         */
 
 /*
     if this is a primary array, then the input COLNUM parameter should
-    be interpreted as the row number, and we will alway read the image
+    be interpreted as the row number, and we will always read the image
     data from column 2 (any group parameters are in column 1).
 */
     if (ffghdt(fptr, &hdutype, status) > 0)
@@ -731,7 +731,7 @@ int ffgcli( fitsfile *fptr,   /* I - FITS file pointer                       */
     /*----------------------------------------------------------------------*/
     convert = 1;
     if (tcode == TSHORT) /* Special Case:                        */
-    {                             /* no type convertion required, so read */
+    {                             /* no type conversion required, so read */
                                   /* data directly into output buffer.    */
 
         if (nelem < (LONGLONG)INT32_MAX/2) {
@@ -748,7 +748,7 @@ int ffgcli( fitsfile *fptr,   /* I - FITS file pointer                       */
     /*  Now read the pixels from the FITS column. If the column does not   */
     /*  have the same datatype as the output array, then we have to read   */
     /*  the raw values into a temporary buffer (of limited size).  In      */
-    /*  the case of a vector colum read only 1 vector of values at a time  */
+    /*  the case of a vector column read only 1 vector of values at a time  */
     /*  then skip to the next row if more values need to be read.          */
     /*  After reading the raw values, then call the fffXXYY routine to (1) */
     /*  test for undefined values, (2) convert the datatype if necessary,  */

--- a/getcolj.c
+++ b/getcolj.c
@@ -259,7 +259,7 @@ int ffgsvj(fitsfile *fptr, /* I - FITS file pointer                         */
 
 /*
     if this is a primary array, then the input COLNUM parameter should
-    be interpreted as the row number, and we will alway read the image
+    be interpreted as the row number, and we will always read the image
     data from column 2 (any group parameters are in column 1).
 */
     if (ffghdt(fptr, &hdutype, status) > 0)
@@ -434,7 +434,7 @@ int ffgsfj(fitsfile *fptr, /* I - FITS file pointer                         */
 
 /*
     if this is a primary array, then the input COLNUM parameter should
-    be interpreted as the row number, and we will alway read the image
+    be interpreted as the row number, and we will always read the image
     data from column 2 (any group parameters are in column 1).
 */
     if (ffghdt(fptr, &hdutype, status) > 0)
@@ -730,7 +730,7 @@ int ffgclj( fitsfile *fptr,   /* I - FITS file pointer                       */
     /*----------------------------------------------------------------------*/
     convert = 1;
     if ((tcode == TLONG) && (LONGSIZE == 32))  /* Special Case:                        */
-    {                             /* no type convertion required, so read */
+    {                             /* no type conversion required, so read */
                                   /* data directly into output buffer.    */
 
         if (nelem < (LONGLONG)INT32_MAX/4) {
@@ -747,7 +747,7 @@ int ffgclj( fitsfile *fptr,   /* I - FITS file pointer                       */
     /*  Now read the pixels from the FITS column. If the column does not   */
     /*  have the same datatype as the output array, then we have to read   */
     /*  the raw values into a temporary buffer (of limited size).  In      */
-    /*  the case of a vector colum read only 1 vector of values at a time  */
+    /*  the case of a vector column read only 1 vector of values at a time  */
     /*  then skip to the next row if more values need to be read.          */
     /*  After reading the raw values, then call the fffXXYY routine to (1) */
     /*  test for undefined values, (2) convert the datatype if necessary,  */
@@ -2199,7 +2199,7 @@ int ffgsvjj(fitsfile *fptr, /* I - FITS file pointer                         */
 
 /*
     if this is a primary array, then the input COLNUM parameter should
-    be interpreted as the row number, and we will alway read the image
+    be interpreted as the row number, and we will always read the image
     data from column 2 (any group parameters are in column 1).
 */
     if (ffghdt(fptr, &hdutype, status) > 0)
@@ -2374,7 +2374,7 @@ int ffgsfjj(fitsfile *fptr, /* I - FITS file pointer                         */
 
 /*
     if this is a primary array, then the input COLNUM parameter should
-    be interpreted as the row number, and we will alway read the image
+    be interpreted as the row number, and we will always read the image
     data from column 2 (any group parameters are in column 1).
 */
     if (ffghdt(fptr, &hdutype, status) > 0)
@@ -2672,7 +2672,7 @@ int ffgcljj( fitsfile *fptr,   /* I - FITS file pointer                       */
     /*----------------------------------------------------------------------*/
     convert = 1;
     if (tcode == TLONGLONG)  /* Special Case:                        */
-    {                             /* no type convertion required, so read */
+    {                             /* no type conversion required, so read */
                                   /* data directly into output buffer.    */
 
         if (nelem < (LONGLONG)INT32_MAX/8) {
@@ -2689,7 +2689,7 @@ int ffgcljj( fitsfile *fptr,   /* I - FITS file pointer                       */
     /*  Now read the pixels from the FITS column. If the column does not   */
     /*  have the same datatype as the output array, then we have to read   */
     /*  the raw values into a temporary buffer (of limited size).  In      */
-    /*  the case of a vector colum read only 1 vector of values at a time  */
+    /*  the case of a vector column read only 1 vector of values at a time  */
     /*  then skip to the next row if more values need to be read.          */
     /*  After reading the raw values, then call the fffXXYY routine to (1) */
     /*  test for undefined values, (2) convert the datatype if necessary,  */

--- a/getcolk.c
+++ b/getcolk.c
@@ -260,7 +260,7 @@ int ffgsvk(fitsfile *fptr, /* I - FITS file pointer                         */
 
 /*
     if this is a primary array, then the input COLNUM parameter should
-    be interpreted as the row number, and we will alway read the image
+    be interpreted as the row number, and we will always read the image
     data from column 2 (any group parameters are in column 1).
 */
     if (ffghdt(fptr, &hdutype, status) > 0)
@@ -435,7 +435,7 @@ int ffgsfk(fitsfile *fptr, /* I - FITS file pointer                         */
 
 /*
     if this is a primary array, then the input COLNUM parameter should
-    be interpreted as the row number, and we will alway read the image
+    be interpreted as the row number, and we will always read the image
     data from column 2 (any group parameters are in column 1).
 */
     if (ffghdt(fptr, &hdutype, status) > 0)
@@ -747,7 +747,7 @@ int ffgclk( fitsfile *fptr,   /* I - FITS file pointer                       */
     /*----------------------------------------------------------------------*/
     convert = 1;
     if (tcode == TLONG)           /* Special Case:                        */
-    {                             /* no type convertion required, so read */
+    {                             /* no type conversion required, so read */
                                   /* data directly into output buffer.    */
 
         if (nelem < (LONGLONG)INT32_MAX/4) {
@@ -764,7 +764,7 @@ int ffgclk( fitsfile *fptr,   /* I - FITS file pointer                       */
     /*  Now read the pixels from the FITS column. If the column does not   */
     /*  have the same datatype as the output array, then we have to read   */
     /*  the raw values into a temporary buffer (of limited size).  In      */
-    /*  the case of a vector colum read only 1 vector of values at a time  */
+    /*  the case of a vector column read only 1 vector of values at a time  */
     /*  then skip to the next row if more values need to be read.          */
     /*  After reading the raw values, then call the fffXXYY routine to (1) */
     /*  test for undefined values, (2) convert the datatype if necessary,  */

--- a/getcoll.c
+++ b/getcoll.c
@@ -357,7 +357,7 @@ int ffgcxui(fitsfile *fptr,   /* I - FITS file pointer                       */
             int  *status)     /* IO - error status                           */
 /*
   Read a consecutive string of bits from an 'X' or 'B' column and
-  interprete them as an unsigned integer.  The number of bits must be
+  interpret them as an unsigned integer.  The number of bits must be
   less than or equal to 16 or the total number of bits in the column, 
   which ever is less.
 */
@@ -494,7 +494,7 @@ int ffgcxuk(fitsfile *fptr,   /* I - FITS file pointer                       */
             int  *status)     /* IO - error status                           */
 /*
   Read a consecutive string of bits from an 'X' or 'B' column and
-  interprete them as an unsigned integer.  The number of bits must be
+  interpret them as an unsigned integer.  The number of bits must be
   less than or equal to 32 or the total number of bits in the column, 
   which ever is less.
 */

--- a/getcols.c
+++ b/getcols.c
@@ -71,7 +71,7 @@ int ffgcls( fitsfile *fptr,   /* I - FITS file pointer                       */
             int  *status)     /* IO - error status                           */
 /*
   Read an array of string values from a column in the current FITS HDU.
-  Returns a formated string value, regardless of the datatype of the column
+  Returns a formatted string value, regardless of the datatype of the column
 */
 {
     int tcode, hdutype, tstatus, scaled, intcol, dwidth, nulwidth, ll, dlen;
@@ -189,7 +189,7 @@ int ffgcls( fitsfile *fptr,   /* I - FITS file pointer                       */
          if (!cform[0])
              strcpy(cform, "%14.6E");
 
-         /* write the formated string for each value:  "(real,imag)" */
+         /* write the formatted string for each value:  "(real,imag)" */
          jj = 0;
          for (ii = 0; ii < nelem; ii++)
          {
@@ -281,7 +281,7 @@ int ffgcls( fitsfile *fptr,   /* I - FITS file pointer                       */
          if (!cform[0])
             strcpy(cform, "%23.15E");
 
-         /* write the formated string for each value:  "(real,imag)" */
+         /* write the formatted string for each value:  "(real,imag)" */
          jj = 0;
          for (ii = 0; ii < nelem; ii++)
          {
@@ -346,7 +346,7 @@ int ffgcls( fitsfile *fptr,   /* I - FITS file pointer                       */
          return(*status);
       }
 
-      /* write the formated string for each value */
+      /* write the formatted string for each value */
       if (nulval) {
           strncpy(tmpnull, nulval,79);
           tmpnull[79]='\0'; /* In case len(nulval) >= 79 */
@@ -404,7 +404,7 @@ int ffgcls( fitsfile *fptr,   /* I - FITS file pointer                       */
          return(*status);
       }
 
-      /* write the formated string for each value */
+      /* write the formatted string for each value */
       if (nulval) {
           strncpy(tmpnull, nulval, 79);
           tmpnull[79]='\0'; /* In case len(nulval) >= 79 */
@@ -562,7 +562,7 @@ int ffgcls( fitsfile *fptr,   /* I - FITS file pointer                       */
           nulwidth = 1;
       }
 
-      /* write the formated string for each value */
+      /* write the formatted string for each value */
       for (ii = 0; ii < nelem; ii++)
       {
            if (tcode == TBIT)

--- a/getcolsb.c
+++ b/getcolsb.c
@@ -260,7 +260,7 @@ int ffgsvsb(fitsfile *fptr, /* I - FITS file pointer                        */
 
 /*
     if this is a primary array, then the input COLNUM parameter should
-    be interpreted as the row number, and we will alway read the image
+    be interpreted as the row number, and we will always read the image
     data from column 2 (any group parameters are in column 1).
 */
     if (ffghdt(fptr, &hdutype, status) > 0)
@@ -435,7 +435,7 @@ int ffgsfsb(fitsfile *fptr, /* I - FITS file pointer                        */
 
 /*
     if this is a primary array, then the input COLNUM parameter should
-    be interpreted as the row number, and we will alway read the image
+    be interpreted as the row number, and we will always read the image
     data from column 2 (any group parameters are in column 1).
 */
     if (ffghdt(fptr, &hdutype, status) > 0)
@@ -769,7 +769,7 @@ int ffgclsb(fitsfile *fptr,   /* I - FITS file pointer                       */
     /*  Now read the pixels from the FITS column. If the column does not   */
     /*  have the same datatype as the output array, then we have to read   */
     /*  the raw values into a temporary buffer (of limited size).  In      */
-    /*  the case of a vector colum read only 1 vector of values at a time  */
+    /*  the case of a vector column read only 1 vector of values at a time  */
     /*  then skip to the next row if more values need to be read.          */
     /*  After reading the raw values, then call the fffXXYY routine to (1) */
     /*  test for undefined values, (2) convert the datatype if necessary,  */
@@ -846,7 +846,7 @@ int ffgclsb(fitsfile *fptr,   /* I - FITS file pointer                       */
                      ffgbytoff(fptr, twidth, ntodo, incre - twidth, buffer,
                                status);
 
-                /* interpret the string as an ASCII formated number */
+                /* interpret the string as an ASCII formatted number */
                 fffstrs1((char *) buffer, ntodo, scale, zero, twidth, power,
                       nulcheck, snull, nulval, &nularray[next], anynul,
                       &array[next], status);

--- a/getcolui.c
+++ b/getcolui.c
@@ -260,7 +260,7 @@ int ffgsvui(fitsfile *fptr, /* I - FITS file pointer                         */
 
 /*
     if this is a primary array, then the input COLNUM parameter should
-    be interpreted as the row number, and we will alway read the image
+    be interpreted as the row number, and we will always read the image
     data from column 2 (any group parameters are in column 1).
 */
     if (ffghdt(fptr, &hdutype, status) > 0)
@@ -423,7 +423,7 @@ int ffgsfui(fitsfile *fptr, /* I - FITS file pointer                         */
 
 /*
     if this is a primary array, then the input COLNUM parameter should
-    be interpreted as the row number, and we will alway read the image
+    be interpreted as the row number, and we will always read the image
     data from column 2 (any group parameters are in column 1).
 */
     if (ffghdt(fptr, &hdutype, status) > 0)
@@ -715,7 +715,7 @@ int ffgclui( fitsfile *fptr,   /* I - FITS file pointer                       */
     /*  not need to use a temporary buffer to store intermediate datatype.  */
     /*----------------------------------------------------------------------*/
     if (tcode == TSHORT) /* Special Case:                        */
-    {                             /* no type convertion required, so read */
+    {                             /* no type conversion required, so read */
                                   /* data directly into output buffer.    */
 
         if (nelem < (LONGLONG)INT32_MAX/2) {
@@ -729,7 +729,7 @@ int ffgclui( fitsfile *fptr,   /* I - FITS file pointer                       */
     /*  Now read the pixels from the FITS column. If the column does not   */
     /*  have the same datatype as the output array, then we have to read   */
     /*  the raw values into a temporary buffer (of limited size).  In      */
-    /*  the case of a vector colum read only 1 vector of values at a time  */
+    /*  the case of a vector column read only 1 vector of values at a time  */
     /*  then skip to the next row if more values need to be read.          */
     /*  After reading the raw values, then call the fffXXYY routine to (1) */
     /*  test for undefined values, (2) convert the datatype if necessary,  */

--- a/getcoluj.c
+++ b/getcoluj.c
@@ -260,7 +260,7 @@ int ffgsvuj(fitsfile *fptr, /* I - FITS file pointer                         */
 
 /*
     if this is a primary array, then the input COLNUM parameter should
-    be interpreted as the row number, and we will alway read the image
+    be interpreted as the row number, and we will always read the image
     data from column 2 (any group parameters are in column 1).
 */
     if (ffghdt(fptr, &hdutype, status) > 0)
@@ -424,7 +424,7 @@ int ffgsfuj(fitsfile *fptr, /* I - FITS file pointer                         */
 
 /*
     if this is a primary array, then the input COLNUM parameter should
-    be interpreted as the row number, and we will alway read the image
+    be interpreted as the row number, and we will always read the image
     data from column 2 (any group parameters are in column 1).
 */
     if (ffghdt(fptr, &hdutype, status) > 0)
@@ -716,7 +716,7 @@ int ffgcluj(fitsfile *fptr,   /* I - FITS file pointer                       */
     /*  not need to use a temporary buffer to store intermediate datatype.  */
     /*----------------------------------------------------------------------*/
     if ((tcode == TLONG) && (LONGSIZE == 32))  /* Special Case:                        */
-    {                             /* no type convertion required, so read */
+    {                             /* no type conversion required, so read */
                                   /* data directly into output buffer.    */
 
         if (nelem < (LONGLONG)INT32_MAX/4) {
@@ -730,7 +730,7 @@ int ffgcluj(fitsfile *fptr,   /* I - FITS file pointer                       */
     /*  Now read the pixels from the FITS column. If the column does not   */
     /*  have the same datatype as the output array, then we have to read   */
     /*  the raw values into a temporary buffer (of limited size).  In      */
-    /*  the case of a vector colum read only 1 vector of values at a time  */
+    /*  the case of a vector column read only 1 vector of values at a time  */
     /*  then skip to the next row if more values need to be read.          */
     /*  After reading the raw values, then call the fffXXYY routine to (1) */
     /*  test for undefined values, (2) convert the datatype if necessary,  */
@@ -2220,7 +2220,7 @@ int ffgsvujj(fitsfile *fptr, /* I - FITS file pointer                         */
 
 /*
     if this is a primary array, then the input COLNUM parameter should
-    be interpreted as the row number, and we will alway read the image
+    be interpreted as the row number, and we will always read the image
     data from column 2 (any group parameters are in column 1).
 */
     if (ffghdt(fptr, &hdutype, status) > 0)
@@ -2395,7 +2395,7 @@ int ffgsfujj(fitsfile *fptr, /* I - FITS file pointer                         */
 
 /*
     if this is a primary array, then the input COLNUM parameter should
-    be interpreted as the row number, and we will alway read the image
+    be interpreted as the row number, and we will always read the image
     data from column 2 (any group parameters are in column 1).
 */
     if (ffghdt(fptr, &hdutype, status) > 0)
@@ -2693,7 +2693,7 @@ int ffgclujj( fitsfile *fptr,   /* I - FITS file pointer                       *
     /*  Now read the pixels from the FITS column. If the column does not   */
     /*  have the same datatype as the output array, then we have to read   */
     /*  the raw values into a temporary buffer (of limited size).  In      */
-    /*  the case of a vector colum read only 1 vector of values at a time  */
+    /*  the case of a vector column read only 1 vector of values at a time  */
     /*  then skip to the next row if more values need to be read.          */
     /*  After reading the raw values, then call the fffXXYY routine to (1) */
     /*  test for undefined values, (2) convert the datatype if necessary,  */

--- a/getcoluk.c
+++ b/getcoluk.c
@@ -260,7 +260,7 @@ int ffgsvuk(fitsfile *fptr, /* I - FITS file pointer                         */
 
 /*
     if this is a primary array, then the input COLNUM parameter should
-    be interpreted as the row number, and we will alway read the image
+    be interpreted as the row number, and we will always read the image
     data from column 2 (any group parameters are in column 1).
 */
     if (ffghdt(fptr, &hdutype, status) > 0)
@@ -424,7 +424,7 @@ int ffgsfuk(fitsfile *fptr, /* I - FITS file pointer                         */
 
 /*
     if this is a primary array, then the input COLNUM parameter should
-    be interpreted as the row number, and we will alway read the image
+    be interpreted as the row number, and we will always read the image
     data from column 2 (any group parameters are in column 1).
 */
     if (ffghdt(fptr, &hdutype, status) > 0)
@@ -747,7 +747,7 @@ int ffgcluk( fitsfile *fptr,  /* I - FITS file pointer                       */
     /*  Now read the pixels from the FITS column. If the column does not   */
     /*  have the same datatype as the output array, then we have to read   */
     /*  the raw values into a temporary buffer (of limited size).  In      */
-    /*  the case of a vector colum read only 1 vector of values at a time  */
+    /*  the case of a vector column read only 1 vector of values at a time  */
     /*  then skip to the next row if more values need to be read.          */
     /*  After reading the raw values, then call the fffXXYY routine to (1) */
     /*  test for undefined values, (2) convert the datatype if necessary,  */

--- a/getkey.c
+++ b/getkey.c
@@ -945,7 +945,7 @@ int ffgkls( fitsfile *fptr,     /* I - FITS file pointer             */
                 /* Without this, for case of a last CONTINUE statement ending
                    with a '&', nextcomm would retain the same string from 
                    from the previous loop iteration and the comment
-                   would get concantenated twice. */
+                   would get concatenated twice. */
                 nextcomm[0] = 0;
             }
 
@@ -1054,7 +1054,7 @@ int ffgsky( fitsfile *fptr,     /* I - FITS file pointer             */
                 /* Without this, for case of a last CONTINUE statement ending
                    with a '&', nextcomm would retain the same string from 
                    from the previous loop iteration and the comment
-                   would get concantenated twice. */
+                   would get concatenated twice. */
                 nextcomm[0] = 0;
             }
 
@@ -2170,7 +2170,7 @@ int ffghpr(fitsfile *fptr,  /* I - FITS file pointer                        */
            long naxes[],    /* O - length of each data axis                 */
            long *pcount,    /* O - number of group parameters (usually 0)   */
            long *gcount,    /* O - number of random groups (usually 1 or 0) */
-           int *extend,     /* O - may FITS file haave extensions?          */
+           int *extend,     /* O - may FITS file have extensions?          */
            int *status)     /* IO - error status                            */
 /*
   Get keywords from the Header of the PRimary array:
@@ -2206,7 +2206,7 @@ int ffghprll(fitsfile *fptr,  /* I - FITS file pointer                        */
            LONGLONG naxes[],    /* O - length of each data axis                 */
            long *pcount,    /* O - number of group parameters (usually 0)   */
            long *gcount,    /* O - number of random groups (usually 1 or 0) */
-           int *extend,     /* O - may FITS file haave extensions?          */
+           int *extend,     /* O - may FITS file have extensions?          */
            int *status)     /* IO - error status                            */
 /*
   Get keywords from the Header of the PRimary array:
@@ -2765,7 +2765,7 @@ int ffgphd(fitsfile *fptr,  /* I - FITS file pointer                        */
            LONGLONG naxes[],    /* O - length of each data axis                 */
            long *pcount,    /* O - number of group parameters (usually 0)   */
            long *gcount,    /* O - number of random groups (usually 1 or 0) */
-           int *extend,     /* O - may FITS file haave extensions?          */
+           int *extend,     /* O - may FITS file have extensions?          */
            double *bscale,  /* O - array pixel linear scaling factor        */
            double *bzero,   /* O - array pixel linear scaling zero point    */
            LONGLONG *blank, /* O - value used to represent undefined pixels */
@@ -2994,7 +2994,7 @@ int ffgphd(fitsfile *fptr,  /* I - FITS file pointer                        */
     for (; !found_end; nextkey++)  
     {
       /* get next keyword */
-      /* don't use ffgkyn here because it trys to parse the card to read */
+      /* don't use ffgkyn here because it tries to parse the card to read */
       /* the value string, thus failing to read the file just because of */
       /* minor syntax errors in optional keywords.                       */
 

--- a/group.c
+++ b/group.c
@@ -1,4 +1,4 @@
-/*  This file, group.c, contains the grouping convention suport routines.  */
+/*  This file, group.c, contains the grouping convention support routines.  */
 
 /*  The FITSIO software was written by William Pence at the High Energy    */
 /*  Astrophysic Science Archive Research Center (HEASARC) at the NASA      */
@@ -49,7 +49,7 @@ D. Jennings, 01/02/99, ffgtop() now looks for relatve file paths when
                        the GRPLCn keyword value is supplied in the member
 		       HDU header.
 
-D. Jennings, 01/02/99, ffgtam() now trys to construct relative file paths
+D. Jennings, 01/02/99, ffgtam() now tries to construct relative file paths
                        from the member's file to the group table's file
 		       (and visa versa) when both the member's file and
 		       group table file are of access type FILE://.
@@ -82,7 +82,7 @@ int ffgtcr(fitsfile *fptr,      /* FITS file pointer                         */
 	   char    *grpname,    /* name of the grouping table                */
 	   int      grouptype,  /* code specifying the type of
 				   grouping table information:
-				   GT_ID_ALL_URI  0 ==> defualt (all columns)
+				   GT_ID_ALL_URI  0 ==> default (all columns)
 				   GT_ID_REF      1 ==> ID by reference
 				   GT_ID_POS      2 ==> ID by position
 				   GT_ID_ALL      3 ==> ID by ref. and position
@@ -135,7 +135,7 @@ int ffgtis(fitsfile *fptr,      /* FITS file pointer                         */
 	   char    *grpname,    /* name of the grouping table                */
 	   int      grouptype,  /* code specifying the type of
 				   grouping table information:
-				   GT_ID_ALL_URI  0 ==> defualt (all columns)
+				   GT_ID_ALL_URI  0 ==> default (all columns)
 				   GT_ID_REF      1 ==> ID by reference
 				   GT_ID_POS      2 ==> ID by position
 				   GT_ID_ALL      3 ==> ID by ref. and position
@@ -274,7 +274,7 @@ int ffgtis(fitsfile *fptr,      /* FITS file pointer                         */
 int ffgtch(fitsfile *gfptr,     /* FITS pointer to group                     */
 	   int       grouptype, /* code specifying the type of
 				   grouping table information:
-				   GT_ID_ALL_URI  0 ==> defualt (all columns)
+				   GT_ID_ALL_URI  0 ==> default (all columns)
 				   GT_ID_REF      1 ==> ID by reference
 				   GT_ID_POS      2 ==> ID by position
 				   GT_ID_ALL      3 ==> ID by ref. and position
@@ -531,7 +531,7 @@ int ffgtch(fitsfile *gfptr,     /* FITS pointer to group                     */
 					status);
 
 	      for(j = 1; j <= nrows && *status == 0; ++j)
-	    /* WILL THIS WORK FOR VAR LENTH CHAR COLS??????*/
+	    /* WILL THIS WORK FOR VAR LENGTH CHAR COLS??????*/
 		*status = fits_write_col_byt(gfptr,colnum,j,1,1,charNull,
 					     status);
 	    }
@@ -650,7 +650,7 @@ int ffgtcp(fitsfile *infptr,  /* input FITS file pointer                     */
 	   fitsfile *outfptr, /* output FITS file pointer                    */
 	   int        cpopt,  /* code specifying copy options:
 				OPT_GCP_GPT (0) ==> copy only grouping table
-				OPT_GCP_ALL (2) ==> recusrively copy members 
+				OPT_GCP_ALL (2) ==> recursively copy members 
 				                    and their members (if 
 						    groups)                  */
 	   int      *status)  /* return status code                          */
@@ -659,7 +659,7 @@ int ffgtcp(fitsfile *infptr,  /* input FITS file pointer                     */
   copy a grouping table, and optionally all its members, to a new FITS file.
   If the cpopt is set to OPT_GCP_GPT (copy grouping table only) then the 
   existing members have their GRPIDn and GRPLCn keywords updated to reflect 
-  the existance of the new group, since they now belong to another group. If 
+  the existence of the new group, since they now belong to another group. If 
   cpopt is set to OPT_GCP_ALL (copy grouping table and members recursively) 
   then the original members are not updated; the new grouping table is 
   modified to include only the copied member HDUs and not the original members.
@@ -884,7 +884,7 @@ int ffgtcm(fitsfile *gfptr,  /* FITS file pointer to grouping table          */
 int ffgtvf(fitsfile *gfptr,       /* FITS file pointer to group             */
 	   long     *firstfailed, /* Member ID (if positive) of first failed
 				     member HDU verify check or GRPID index
-				     (if negitive) of first failed group
+				     (if negative) of first failed group
 				     link verify check.                     */
 	   int      *status)      /* return status code                     */
 
@@ -1210,7 +1210,7 @@ int ffgtop(fitsfile *mfptr,  /* FITS file pointer to the member HDU          */
 	      
 	      *status = fits_relurl2url(url[i],keyvalue,location,status);
 	      
-	      /* if an error occured then contniue */
+	      /* if an error occurred then continue */
 	      
 	      if(*status != 0) 
 		{
@@ -1253,7 +1253,7 @@ int ffgtop(fitsfile *mfptr,  /* FITS file pointer to the member HDU          */
 
 	}while(0); /* end of file opening loop */
 
-      /* if an error occured with the file opening then exit */
+      /* if an error occurred with the file opening then exit */
 
       if(*status != 0) continue;
   
@@ -1298,7 +1298,7 @@ int ffgtam(fitsfile *gfptr,   /* FITS file pointer to grouping table HDU     */
   have the appropriate GRPIDn and GRPLCn keywords created in its header.
 
   Note that if the member HDU to be added to the grouping table is already
-  a member of the group then it will not be added a sceond time.
+  a member of the group then it will not be added a second time.
 */
 
 {
@@ -1687,7 +1687,7 @@ int ffgtam(fitsfile *gfptr,   /* FITS file pointer to grouping table HDU     */
 	  if(strlen(memberExtname) != 0)
 	    fits_write_col_str(gfptr,extnameCol,nmembers,1,1,tmpPtr,status);
 	  else
-	    /* WILL THIS WORK FOR VAR LENTH CHAR COLS??????*/
+	    /* WILL THIS WORK FOR VAR LENGTH CHAR COLS??????*/
 	    fits_write_col_byt(gfptr,extnameCol,nmembers,1,1,charNull,status);
 	}
 
@@ -1714,7 +1714,7 @@ int ffgtam(fitsfile *gfptr,   /* FITS file pointer to grouping table HDU     */
 	          strncmp(tmprootname, grootname, FLEN_FILENAME))
 	    fits_write_col_str(gfptr,locationCol,nmembers,1,1,tmpPtr,status);
 	  else
-	    /* WILL THIS WORK FOR VAR LENTH CHAR COLS??????*/
+	    /* WILL THIS WORK FOR VAR LENGTH CHAR COLS??????*/
 	    fits_write_col_byt(gfptr,locationCol,nmembers,1,1,charNull,status);
 	}
 
@@ -1734,7 +1734,7 @@ int ffgtam(fitsfile *gfptr,   /* FITS file pointer to grouping table HDU     */
 	          strncmp(tmprootname, grootname, FLEN_FILENAME))
 	    fits_write_col_str(gfptr,uriCol,nmembers,1,1,tmpPtr,status);
 	  else
-	    /* WILL THIS WORK FOR VAR LENTH CHAR COLS??????*/
+	    /* WILL THIS WORK FOR VAR LENGTH CHAR COLS??????*/
 	    fits_write_col_byt(gfptr,uriCol,nmembers,1,1,charNull,status);
 	}
     } while(0);
@@ -2010,7 +2010,7 @@ int ffgmng(fitsfile *mfptr,   /* FITS file pointer to member HDU            */
   return the number of groups to which a HDU belongs, as defined by the number
   of GRPIDn/GRPLCn keyword records that appear in the HDU header. The 
   fitsfile pointer mfptr must be positioned with the member HDU as the CHDU. 
-  Each time this function is called, the indicies of the GRPIDn/GRPLCn
+  Each time this function is called, the indices of the GRPIDn/GRPLCn
   keywords are checked to make sure they are continuous (ie no gaps) and
   are re-enumerated to eliminate gaps if gaps are found to be present.
 */
@@ -2415,7 +2415,7 @@ int ffgmop(fitsfile *gfptr,  /* FITS file pointer to grouping table          */
 		     CASE 3:
 
 		     If we got this far then the URL does not specify an
-		     absoulte file path or URL with access method. Since 
+		     absolute file path or URL with access method. Since 
 		     the path to the group table's file is (obviously) valid 
 		     for the CWD, create a full location string for the
 		     member HDU using the grouping table URL as a basis
@@ -2606,7 +2606,7 @@ int ffgmop(fitsfile *gfptr,  /* FITS file pointer to grouping table          */
 
 	  /*
 	    try to find the member hdu in the the FITS file pointed to
-	    by mfptr based upon its HDU posistion value. Note that is 
+	    by mfptr based upon its HDU position value. Note that is 
 	    impossible to verify if the HDU is actually the correct HDU due 
 	    to a lack of information.
 	  */
@@ -2932,7 +2932,7 @@ int ffgmtf(fitsfile *infptr,   /* FITS file pointer to source grouping table */
   member of the target group and remains a member of the source group. If
   the tfopt parameter is OPT_MCP_MOV then the member is deleted from the 
   source group after the transfer to the destination group. The member to be
-  transfered is identified by its row number within the source grouping table.
+  transferred is identified by its row number within the source grouping table.
 */
 
 {
@@ -2948,7 +2948,7 @@ int ffgmtf(fitsfile *infptr,   /* FITS file pointer to source grouping table */
     }
   else
     {
-      /* open the member of infptr to be transfered */
+      /* open the member of infptr to be transferred */
 
       *status = fits_open_member(infptr,member,&mfptr,status);
       
@@ -3114,7 +3114,7 @@ int ffgmrm(fitsfile *gfptr,  /* FITS file pointer to group table             */
 	  */
 
 	  /*
-	    there is no need to seach for and remove the GRPIDn/GRPLCn
+	    there is no need to search for and remove the GRPIDn/GRPLCn
 	    keywords from the member HDU if it has not been opened
 	    in READWRITE mode
 	  */
@@ -3306,7 +3306,7 @@ int ffgmrm(fitsfile *gfptr,  /* FITS file pointer to group table             */
 			if the absolute value of GRPIDn is equal to the
 			EXTVER value of the grouping table and (one of the 
 			possible two) grouping table file URL matches the
-			GRPLCn keyword value then we hava a match
+			GRPLCn keyword value then we have a match
 		      */
 		      
 		      if(strcmp(grplc,grpLocation1) == 0  || 
@@ -3620,14 +3620,14 @@ int ffvcfm(fitsfile *gfptr, int xtensionCol, int extnameCol, int extverCol,
 /*****************************************************************************/
 int ffgtdc(int   grouptype,     /* code specifying the type of
 				   grouping table information:
-				   GT_ID_ALL_URI  0 ==> defualt (all columns)
+				   GT_ID_ALL_URI  0 ==> default (all columns)
 				   GT_ID_REF      1 ==> ID by reference
 				   GT_ID_POS      2 ==> ID by position
 				   GT_ID_ALL      3 ==> ID by ref. and position
 				   GT_ID_REF_URI 11 ==> (1) + URI info 
 				   GT_ID_POS_URI 12 ==> (2) + URI info       */
 	   int   xtensioncol, /* does MEMBER_XTENSION already exist?         */
-	   int   extnamecol,  /* does MEMBER_NAME aleady exist?              */
+	   int   extnamecol,  /* does MEMBER_NAME already exist?              */
 	   int   extvercol,   /* does MEMBER_VERSION already exist?          */
 	   int   positioncol, /* does MEMBER_POSITION already exist?         */
 	   int   locationcol, /* does MEMBER_LOCATION already exist?         */
@@ -4003,7 +4003,7 @@ int ffgmul(fitsfile *mfptr,   /* pointer to the grouping table member HDU    */
 
 	  /*
 	     close the file pointed to by gfptr if it is non NULL to
-	     prepare for the next loop iterration
+	     prepare for the next loop iteration
 	  */
 
 	  if(gfptr != NULL)
@@ -4073,7 +4073,7 @@ int ffgmf(fitsfile *gfptr, /* pointer to grouping table HDU to search       */
    found then member is returned with a value of 0 and the status return
    code will be set to MEMBER_NOT_FOUND.
 
-   Note that the member HDU postion information is used to obtain a member
+   Note that the member HDU position information is used to obtain a member
    match only if the grouping table type is GT_ID_POS_URI or GT_ID_POS. This
    is because the position information can become invalid much more
    easily then the reference information for a group member.
@@ -4198,13 +4198,13 @@ int ffgmf(fitsfile *gfptr, /* pointer to grouping table HDU to search       */
       
       /*
 	if no location string was passed to the function then assume that
-	the calling application does not wish to use it as a comparision
-	critera ==> if we got this far then we have a match
+	the calling application does not wish to use it as a comparison
+	criteria ==> if we got this far then we have a match
       */
 
       if(location == NULL)
 	{
-	  ffpmsg("NULL Location string given ==> ingore location (ffgmf)");
+	  ffpmsg("NULL Location string given ==> ignore location (ffgmf)");
 	  *member = i;
 	  continue;
 	}
@@ -4212,7 +4212,7 @@ int ffgmf(fitsfile *gfptr, /* pointer to grouping table HDU to search       */
       /*
 	if the grouping table MEMBER_LOCATION column exists then read the
 	location URL for the member, else set the location string to
-	a zero-length string for subsequent comparisions
+	a zero-length string for subsequent comparisons
       */
 
       if(locationCol != 0)
@@ -4303,7 +4303,7 @@ int ffgmf(fitsfile *gfptr, /* pointer to grouping table HDU to search       */
 		  fits_clean_url(cwd,grpLocation1,status);
 		}
 	      
-	      /* create an absoute URL for the member */
+	      /* create an absolute URL for the member */
 
 	      fits_relurl2url(grpLocation1,mbrLocation1,mbrLocation3,status);
 	      
@@ -4512,7 +4512,7 @@ int ffgtcpr(fitsfile   *infptr,  /* input FITS file pointer                 */
 	    fitsfile   *outfptr, /* output FITS file pointer                */
 	    int         cpopt,   /* code specifying copy options:
 				    OPT_GCP_GPT (0) ==> cp only grouping table
-				    OPT_GCP_ALL (2) ==> recusrively copy 
+				    OPT_GCP_ALL (2) ==> recursively copy 
 				    members and their members (if groups)   */
 	    HDUtracker *HDU,     /* list of already copied HDUs             */
 	    int        *status)  /* return status code                      */
@@ -4520,7 +4520,7 @@ int ffgtcpr(fitsfile   *infptr,  /* input FITS file pointer                 */
 /*
   copy a Group to a new FITS file. If the cpopt parameter is set to 
   OPT_GCP_GPT (copy grouping table only) then the existing members have their 
-  GRPIDn and GRPLCn keywords updated to reflect the existance of the new group,
+  GRPIDn and GRPLCn keywords updated to reflect the existence of the new group,
   since they now belong to another group. If cpopt is set to OPT_GCP_ALL 
   (copy grouping table and members recursively) then the original members are 
   not updated; the new grouping table is modified to include only the copied 
@@ -4821,7 +4821,7 @@ int fftsad(fitsfile   *mfptr,       /* pointer to an member HDU             */
 /*
   add an HDU to the HDUtracker struct pointed to by HDU. The HDU is only 
   added if it does not already reside in the HDUtracker. If it already
-  resides in the HDUtracker then the new HDU postion and file name are
+  resides in the HDUtracker then the new HDU position and file name are
   returned in  newPosition and newFileName (if != NULL)
 */
 
@@ -4968,7 +4968,7 @@ void prepare_keyvalue(char *keyvalue) /* string containing keyword value     */
   strip off all single quote characters "'" and blank spaces from a keyword
   value retrieved via fits_read_key*() routines
 
-  this is necessary so that a standard comparision of keyword values may
+  this is necessary so that a standard comparison of keyword values may
   be made
 */
 
@@ -5014,10 +5014,10 @@ int fits_path2url(char *inpath,  /* input file path string                  */
 		  char *outpath, /* output file path string                 */
 		  int  *status)
   /*
-     convert a file path into its Unix-style equivelent for URL 
+     convert a file path into its Unix-style equivalent for URL 
      purposes. Note that this process is platform dependent. This
      function supports Unix, MSDOS/WIN32, VMS and Macintosh platforms. 
-     The plaform dependant code is conditionally compiled depending upon
+     The platform dependent code is conditionally compiled depending upon
      the setting of the appropriate C preprocessor macros.
    */
 {
@@ -5031,7 +5031,7 @@ int fits_path2url(char *inpath,  /* input file path string                  */
     //disk/path/filename
 
      All path segments may be null, so that a single file name is the
-     simplist case.
+     simplest case.
 
      The leading "//" becomes a single "/" if present. If no "//" is present,
      then make sure the resulting URL path is relative, i.e., does not
@@ -5059,7 +5059,7 @@ int fits_path2url(char *inpath,  /* input file path string                  */
      disk:\path\filename
 
      All path segments may be null, so that a single file name is the
-     simplist case.
+     simplest case.
 
      All back-slashes '\' become slashes '/'; if the path starts with a
      string of the form "X:" then it is replaced with "/X/"
@@ -5123,7 +5123,7 @@ int fits_path2url(char *inpath,  /* input file path string                  */
 
      node::disk:[path]filename.ext;version
 
-     Any part of the file path may be missing, so that in the simplist
+     Any part of the file path may be missing, so that in the simplest
      case a single file name/extension is given.
 
      all brackets "[", "]" and dots "." become "/"; dashes "-" become "..", 
@@ -5389,7 +5389,7 @@ int fits_url2path(char *inpath,  /* input file path string  */
      Note that this process is platform dependent. This
      function supports Unix, MSDOS/WIN32, VMS and Macintosh platforms. Each
      platform dependent code segment is conditionally compiled depending 
-     upon the setting of the appropriate C preprocesser macros.
+     upon the setting of the appropriate C preprocessor macros.
    */
 {
   char buff[FLEN_FILENAME];
@@ -5435,7 +5435,7 @@ int fits_url2path(char *inpath,  /* input file path string  */
     //disk/path/filename
 
      All path segments but the last may be null, so that a single file name 
-     is the simplist case.     
+     is the simplest case.     
   */
 
   if(absolute)
@@ -5457,7 +5457,7 @@ int fits_url2path(char *inpath,  /* input file path string  */
      disk:\path\filename
 
      All path segments but the last may be null, so that a single file name 
-     is the simplist case.
+     is the simplest case.
   */
 
   /*
@@ -5496,7 +5496,7 @@ int fits_url2path(char *inpath,  /* input file path string  */
      node::disk:[path]filename.ext;version
 
      Any part of the file path may be missing execpt filename.ext, so that in 
-     the simplist case a single file name/extension is given.
+     the simplest case a single file name/extension is given.
 
      if the path is specified as relative starting with "./" then the first
      part of the VMS path is "[.". If the path is relative and does not start
@@ -5560,7 +5560,7 @@ int fits_url2path(char *inpath,  /* input file path string  */
       else
 	{
 	  /*
-	    process the token as a a directory path segement
+	    process the token as a a directory path segment
 	  */
 
 	  if(absolute)
@@ -5594,7 +5594,7 @@ int fits_url2path(char *inpath,  /* input file path string  */
      disk:path:filename
 
      All path segments but the last may be null, so that a single file name 
-     is the simplist case.
+     is the simplest case.
   */
 
   /*
@@ -5639,7 +5639,7 @@ int fits_get_cwd(char *cwd,  /* IO current working directory string */
      Note that this process is platform dependent. This
      function supports Unix, MSDOS/WIN32, VMS and Macintosh platforms. Each
      platform dependent code segment is conditionally compiled depending 
-     upon the setting of the appropriate C preprocesser macros.
+     upon the setting of the appropriate C preprocessor macros.
    */
 {
 
@@ -5715,7 +5715,7 @@ int  fits_get_url(fitsfile *fptr,       /* I ptr to FITS file to evaluate    */
     {
       /* 
 	 retrieve the member HDU's file name as opened by ffopen() 
-	 and parse it into its constitutent pieces; get the currently
+	 and parse it into its constituent pieces; get the currently
 	 active driver token too
        */
 	  
@@ -5939,21 +5939,21 @@ int  fits_get_url(fitsfile *fptr,       /* I ptr to FITS file to evaluate    */
       else if(fits_strcasecmp(tmpStr3,"stdin://")        == 0)        
 	{
 	  *status = URL_PARSE_ERROR;
-	  ffpmsg("cannot make vaild URL from stdin:// (fits_get_url)");
+	  ffpmsg("cannot make valid URL from stdin:// (fits_get_url)");
 	  *tmpStr1 = *tmpStr2 = 0;
 	}
 
       else if(fits_strcasecmp(tmpStr3,"stdout://")       == 0)       
 	{
 	  *status = URL_PARSE_ERROR;
-	  ffpmsg("cannot make vaild URL from stdout:// (fits_get_url)");
+	  ffpmsg("cannot make valid URL from stdout:// (fits_get_url)");
 	  *tmpStr1 = *tmpStr2 = 0;
 	}
 
       else if(fits_strcasecmp(tmpStr3,"irafmem://")      == 0)      
 	{
 	  *status = URL_PARSE_ERROR;
-	  ffpmsg("cannot make vaild URL from irafmem:// (fits_get_url)");
+	  ffpmsg("cannot make valid URL from irafmem:// (fits_get_url)");
 	  *tmpStr1 = *tmpStr2 = 0;
 	}
 
@@ -6229,7 +6229,7 @@ static grp_stack_data shift_grp_stack(grp_stack* mystack) {
 
 /*--------------------------------------------------------------------------*/
 int fits_url2relurl(char     *refURL, /* I reference URL string             */
-		    char     *absURL, /* I absoulute URL string to process  */
+		    char     *absURL, /* I absolute URL string to process  */
 		    char     *relURL, /* O resulting relative URL string    */
 		    int      *status)
 /*
@@ -6241,8 +6241,8 @@ int fits_url2relurl(char     *refURL, /* I reference URL string             */
   signifiying that they are absolute file paths.
 
   Note that it is possible to make a relative URL from two input URLs
-  (absURL and refURL) that are not compatable. This function does not
-  check to see if the resulting relative URL makes any sence. For instance,
+  (absURL and refURL) that are not compatible. This function does not
+  check to see if the resulting relative URL makes any sense. For instance,
   it is impossible to make a relative URL from the following two inputs:
 
   absURL = ftp://a.b.c.com/x/y/z/foo.fits
@@ -6315,7 +6315,7 @@ int fits_url2relurl(char     *refURL, /* I reference URL string             */
 	  
 	  /* We found a difference in the paths in refURL and absURL.
 	     For every path segment remaining in the refURL string, append
-	     a "../" path segment to the relataive URL relURL.
+	     a "../" path segment to the relative URL relURL.
 	  */
 
 	  for(j = refcount; j < refsize; ++j)
@@ -6436,8 +6436,8 @@ int fits_relurl2url(char     *refURL, /* I reference URL string             */
 	  /*
 	    have to parse the refURL string for the first occurnace of the 
 	    same number of '/' characters as contained in the beginning of
-	    location that is not followed by a greater number of consective 
-	    '/' charaters (yes, that is a confusing statement); this is the 
+	    location that is not followed by a greater number of consecutive 
+	    '/' characters (yes, that is a confusing statement); this is the 
 	    location in the refURL string where the relURL string is to
 	    be appended to form the new absolute URL string
 	   */
@@ -6534,7 +6534,7 @@ int fits_encode_url(char *inpath,  /* I URL  to be encoded                  */
 		    int *status)
      /*
        encode all URL "unsafe" and "reserved" characters using the "%XX"
-       convention, where XX stand for the two hexidecimal digits of the
+       convention, where XX stand for the two hexadecimal digits of the
        encode character's ASCII code.
 
        Note that the outpath length, as specified by the maxlength argument,
@@ -6579,7 +6579,7 @@ unsigned const char isAcceptable[96] =
     {
       a = (unsigned char)*p;
 
-      /* if the charcter requires encoding then process it */
+      /* if the character requires encoding then process it */
 
       if(!( a>=32 && a<128 && (isAcceptable[a-32])))
 	{
@@ -6630,8 +6630,8 @@ int fits_unencode_url(char *inpath,  /* I input URL with encoding            */
      /*
        unencode all URL "unsafe" and "reserved" characters to their actual
        ASCII representation. All tokens of the form "%XX" where XX is the
-       hexidecimal code for an ASCII character, are searched for and
-       translated into the actuall ASCII character (so three chars become
+       hexadecimal code for an ASCII character, are searched for and
+       translated into the actual ASCII character (so three chars become
        1 char).
 
        It is assumed that OUTPATH has enough room to hold the unencoded
@@ -6708,7 +6708,7 @@ int fits_is_url_absolute(char *url)
   char reserved[] = {':',';','/','?','@','&','=','+','$',','};
 
   /*
-    The rule for determing if an URL is relative or absolute is that it (1)
+    The rule for determining if an URL is relative or absolute is that it (1)
     must have a colon ":" and (2) that the colon must appear before any other
     reserved URL character in the URL string. We first see if a colon exists,
     get its position in the string, and then check to see if any of the other

--- a/grparser.c
+++ b/grparser.c
@@ -27,7 +27,7 @@
 24-Oct-98: syntax change: empty lines and lines with only whitespaces are 
 		written to FITS files as blank keywords (if inside group/hdu
 		definition). Previously lines had to have at least 8 spaces.
-		Please note, that due to pecularities of CFITSIO if the
+		Please note, that due to peculiarities of CFITSIO if the
 		last keyword(s) defined for given HDU are blank keywords
 		consisting of only 80 spaces, then (some of) those keywords
 		may be silently deleted by CFITSIO.
@@ -466,7 +466,7 @@ int	ngp_extract_tokens(NGP_RAW_LINE *cl)
           if ('\'' == *p)			/* we have found doublequote */
             { if ((0 == p[1]) || ('\n' == p[1]))/* doublequote is the last character in line */
                 { *s = 0; return(NGP_OK); }
-              if (('\t' == p[1]) || (' ' == p[1])) /* duoblequote was string terminator */
+              if (('\t' == p[1]) || (' ' == p[1])) /* doublequote was string terminator */
                 { *s = 0; p++; break; }
               if ('\'' == p[1]) p++;		/* doublequote is inside string, convert "" -> " */ 
             }

--- a/grparser.h
+++ b/grparser.h
@@ -49,7 +49,7 @@ extern "C" {
 
 #define	NGP_TTYPE_UNKNOWN	(0)			/* undef (yet) token type - invalid to print/write to disk */
 #define	NGP_TTYPE_BOOL		(1)			/* boolean, it is 'T' or 'F' */
-#define	NGP_TTYPE_STRING	(2)			/* something withing "" or starting with letter */
+#define	NGP_TTYPE_STRING	(2)			/* something within "" or starting with letter */
 #define	NGP_TTYPE_INT		(3)			/* starting with digit and not with '.' */
 #define	NGP_TTYPE_REAL		(4)			/* digits + '.' */
 #define	NGP_TTYPE_COMPLEX	(5)			/* 2 reals, separated with ',' */

--- a/histo.c
+++ b/histo.c
@@ -334,7 +334,7 @@ getweight:
             return(*status);
         }
 
-        /* creat a float datatype histogram by default, if weight */
+        /* create a float datatype histogram by default, if weight */
         /* factor is not = 1.0  */
 
         if ( (defaulttype && *wt != 1.0) || (defaulttype && *wtname) )
@@ -543,7 +543,7 @@ int ffhist2(fitsfile **fptr,  /* IO - pointer to table with X and Y cols;    */
                              /* rows in the table).  If the element is true */
                              /* then the corresponding row of the table will*/
                              /* be included in the histogram, otherwise the */
-                             /* row will be skipped.  Ingnored if *selectrow*/
+                             /* row will be skipped.  Ignored if *selectrow*/
                              /* is equal to NULL.                           */
            int *status)
 {
@@ -580,7 +580,7 @@ int ffhist2(fitsfile **fptr,  /* IO - pointer to table with X and Y cols;    */
 
     
     /*    Calculate the binning parameters:    */
-    /*   columm numbers, axes length, min values,  max values, and binsizes.  */
+    /*   column numbers, axes length, min values,  max values, and binsizes.  */
 
     if (fits_calc_binningd(
       *fptr, naxis, colname, minin, maxin, binsizein, minname, maxname, binname,
@@ -687,7 +687,7 @@ fitsfile *ffhist3(fitsfile *fptr, /* I - ptr to table with X and Y cols*/
                              /* rows in the table).  If the element is true */
                              /* then the corresponding row of the table will*/
                              /* be included in the histogram, otherwise the */
-                             /* row will be skipped.  Ingnored if *selectrow*/
+                             /* row will be skipped.  Ignored if *selectrow*/
                              /* is equal to NULL.                           */
            int *status)
 {
@@ -726,7 +726,7 @@ fitsfile *ffhist3(fitsfile *fptr, /* I - ptr to table with X and Y cols*/
     }
     
     /*    Calculate the binning parameters:    */
-    /*   columm numbers, axes length, min values,  max values, and binsizes.  */
+    /*   column numbers, axes length, min values,  max values, and binsizes.  */
 
     if (fits_calc_binningd(
       fptr, naxis, colname, minin, maxin, binsizein, minname, maxname, binname,
@@ -828,7 +828,7 @@ int ffhist(fitsfile **fptr,  /* IO - pointer to table with X and Y cols;    */
                              /* rows in the table).  If the element is true */
                              /* then the corresponding row of the table will*/
                              /* be included in the histogram, otherwise the */
-                             /* row will be skipped.  Ingnored if *selectrow*/
+                             /* row will be skipped.  Ignored if *selectrow*/
                              /* is equal to NULL.                           */
            int *status)
 {
@@ -1655,7 +1655,7 @@ int fits_calc_binningd(
       }
 
       /* ================================================================ */
-      /* check tha column is not a vector or a string                     */
+      /* check that column is not a vector or a string                     */
 
       colptr = ((fptr)->Fptr)->tableptr;
       colptr += (colnum[ii] - 1);
@@ -2089,7 +2089,7 @@ int fits_make_hist(fitsfile *fptr, /* IO - pointer to table with X and Y cols; *
                              /* rows in the table).  If the element is true */
                              /* then the corresponding row of the table will*/
                              /* be included in the histogram, otherwise the */
-                             /* row will be skipped.  Ingnored if *selectrow*/
+                             /* row will be skipped.  Ignored if *selectrow*/
                              /* is equal to NULL.                           */
     int *status)
 {		  
@@ -2132,7 +2132,7 @@ int fits_make_histd(fitsfile *fptr, /* IO - pointer to table with X and Y cols; 
                              /* rows in the table).  If the element is true */
                              /* then the corresponding row of the table will*/
                              /* be included in the histogram, otherwise the */
-                             /* row will be skipped.  Ingnored if *selectrow*/
+                             /* row will be skipped.  Ignored if *selectrow*/
                              /* is equal to NULL.                           */
     int *status)
 {		  
@@ -2314,7 +2314,7 @@ int fits_get_col_minmax(fitsfile *fptr, int colnum, double *datamin,
 int ffwritehisto(long totaln, long pixoffset, long firstn, long nvalues,
              int narrays, iteratorCol *imagepars, void *userPointer)
 /*
-   Interator work function that writes out the histogram.
+   Iterator work function that writes out the histogram.
    The histogram values are calculated by another work function, ffcalchisto.
    This work function only gets called once, and totaln = nvalues.
 */
@@ -2364,7 +2364,7 @@ int ffwritehisto(long totaln, long pixoffset, long firstn, long nvalues,
     /* call iterator function to calc the histogram pixel values */
 
     /* must lock this call in multithreaded environoments because */
-    /* the ffcalchist work routine uses static vaiables that would */
+    /* the ffcalchist work routine uses static variables that would */
     /* get clobbered if multiple threads were running at the same time */
     FFLOCK;
     fits_iterate_data(ncols, colpars, offset, rows_per_loop,
@@ -2377,7 +2377,7 @@ int ffwritehisto(long totaln, long pixoffset, long firstn, long nvalues,
 int ffcalchist(long totalrows, long offset, long firstrow, long nrows,
              int ncols, iteratorCol *colpars, void *userPointer)
 /*
-   Interator work function that calculates values for the 2D histogram.
+   Iterator work function that calculates values for the 2D histogram.
 */
 {
     long ii, ipix, iaxisbin;

--- a/imcompress.c
+++ b/imcompress.c
@@ -1463,7 +1463,7 @@ int imcomp_calc_max_elem (int comptype, int nx, int zbitpix, int blocksize)
     }
      else if (comptype == HCOMPRESS_1)
     {
-        /* Imperical evidence suggests in the worst case, 
+        /* Emperical evidence suggests in the worst case, 
 	   the compressed stream could be up to 10% larger than the original
 	   image.  Add 26 byte overhead, only significant for very small tiles
 	   
@@ -2781,7 +2781,7 @@ int imcomp_convert_tile_tfloat(
 		     /* Summing the 2 quantities may help avoid cases where 2 executions of the program */
 		     /* (perhaps in a multithreaded environoment) end up with exactly the same dither seed */
 		     /* value.  The sum is incremented by the current HDU number in the file to provide */
-		     /* further randomization.  This randomization is desireable if multiple compressed */
+		     /* further randomization.  This randomization is desirable if multiple compressed */
 		     /* images will be summed (or differenced). In such cases, the benefits of dithering */
 		     /* may be lost if all the images use exactly the same sequence of random numbers when */
 		     /* calculating the dithering offsets. */	     
@@ -3777,7 +3777,7 @@ int fits_write_compressed_pixels(fitsfile *fptr, /* I - FITS file pointer   */
             int  *status)     /* IO - error status                           */
 /*
    Write a consecutive set of pixels to a compressed image.  This routine
-   interpretes the n-dimensional image as a long one-dimensional array. 
+   interprets the n-dimensional image as a long one-dimensional array. 
    This is actually a rather inconvenient way to write compressed images in
    general, and could be rather inefficient if the requested pixels to be
    written are located in many different image compression tiles.    
@@ -4924,7 +4924,7 @@ int fits_read_write_compressed_img(fitsfile *fptr,   /* I - FITS file pointer   
               if (tilenul && anynul) {     
                    /* this assumes that the tiled pixels are in the same order
 		      as in the uncompressed FITS image.  This is not necessarily
-		      the case, but it almost alway is in practice.  
+		      the case, but it almost always is in practice.  
 		      Note that null checking is not performed for integer images,
 		      so this could only be a problem for tile compressed floating
 		      point images that use an unconventional tiling pattern.
@@ -4964,7 +4964,7 @@ int fits_read_compressed_pixels(fitsfile *fptr, /* I - FITS file pointer    */
             int  *status)     /* IO - error status                           */
 /*
    Read a consecutive set of pixels from a compressed image.  This routine
-   interpretes the n-dimensional image as a long one-dimensional array. 
+   interprets the n-dimensional image as a long one-dimensional array. 
    This is actually a rather inconvenient way to read compressed images in
    general, and could be rather inefficient if the requested pixels to be
    read are located in many different image compression tiles.    
@@ -6015,7 +6015,7 @@ int imcomp_decompress_tile (fitsfile *infptr,
                }
             }
             else if (datatype == TDOUBLE && (infptr->Fptr)->zbitpix == FLOAT_IMG) {  
-                /*  have to allocat a temporary buffer for the uncompressed data in the */
+                /*  have to allocate a temporary buffer for the uncompressed data in the */
                 /*  case where a gzipped "float" tile is returned as a "double" array   */
                 tempfloat = (float*) malloc (idatalen); 
 
@@ -6124,7 +6124,7 @@ int imcomp_decompress_tile (fitsfile *infptr,
     /* **************************************************************** */
     /* deal with the normal case of a compressed tile of pixels */
     if (nullcheck == 2)  {
-        for (ii = 0; ii < tilelen; ii++)  /* initialize the null flage array */
+        for (ii = 0; ii < tilelen; ii++)  /* initialize the null flag array */
             bnullarray[ii] = 0;
     }
 
@@ -6446,7 +6446,7 @@ int imcomp_decompress_tile (fitsfile *infptr,
             /*
 	       Hcompress is a special case:  ignore any numerical overflow
 	       errors that may have occurred during the integer*4 to integer*2
-	       convertion.  Overflows can happen when a lossy Hcompress algorithm
+	       conversion.  Overflows can happen when a lossy Hcompress algorithm
 	       is invoked (with a non-zero scale factor).  The fffi4i2 routine
 	       clips the returned values to be within the legal I*2 range, so
 	       all we need to is to reset the error status to zero.
@@ -6901,7 +6901,7 @@ int imcomp_test_overlap (
 
 /* 
   test if there are any intersecting pixels between this tile and the section
-  of the image defined by fixel, lpixel, ininc. 
+  of the image defined by fpixel, lpixel, ininc. 
 */
 {
     long imgdim[MAX_COMPRESS_DIM]; /* product of preceding dimensions in the */
@@ -8007,7 +8007,7 @@ int fits_compress_table(fitsfile *infptr, fitsfile *outfptr, int *status)
   improves the gzip compression of floating-point arrays.
    
   2. Compress the contiguous array of bytes in each column using the specified
-  compression method.  If no method is specifed, then a default method for that
+  compression method.  If no method is specified, then a default method for that
   data type is chosen. 
   
   3. Store the compressed stream of bytes into a column that has the same name
@@ -8021,7 +8021,7 @@ int fits_compress_table(fitsfile *infptr, fitsfile *outfptr, int *status)
   and the second is the set of pointers to the compressed VLAs in the output table.
   The latter set of pointers is used to reconstruct table when it is uncompressed,
   so that the heap has exactly the same structure as in the original file.  The 2
-  sets of pointers are concatinated together, compressed with gzip, and written to
+  sets of pointers are concatenated together, compressed with gzip, and written to
   the output table.  When reading the compressed table, the only VLA that is directly
   visible is this compressed array of descriptors.  One has to uncompress this array
   to be able to to read all the descriptors to the individual VLAs in the column.  
@@ -8115,7 +8115,7 @@ int fits_compress_table(fitsfile *infptr, fitsfile *outfptr, int *status)
     }
    
     /* Check if the chunk size has been specified with the FZTILELN keyword. */
-    /* If not, calculate a default number of rows per chunck, */
+    /* If not, calculate a default number of rows per chunk, */
 
     tstatus = 0;
     if (fits_read_key(infptr, TLONG, "FZTILELN", &rowspertile, NULL, &tstatus)) {
@@ -8281,7 +8281,7 @@ int fits_compress_table(fitsfile *infptr, fitsfile *outfptr, int *status)
         ffmbyt(infptr, datastart, 0, status);
 
         /* ================================================================================*/
-        /*  First, transpose this chunck from row-major order to column-major order  */
+        /*  First, transpose this chunk from row-major order to column-major order  */
 	/*  At the same time, shuffle the bytes in each datum, if doing GZIP_2 compression */
         /* ================================================================================*/
 
@@ -8456,7 +8456,7 @@ int fits_compress_table(fitsfile *infptr, fitsfile *outfptr, int *status)
                            (int) compmemlen, 32);
 		        } else {
 			  /* this should not happen */
-			  ffpmsg(" Error: cannot compress this column type with the RICE algorthm");
+			  ffpmsg(" Error: cannot compress this column type with the RICE algorithm");
 			  free(vlamem); free(cdescript); free(cm_buffer); free(cvlamem);
 			  *status = DATA_COMPRESSION_ERR;
 			  return(*status);
@@ -8476,7 +8476,7 @@ int fits_compress_table(fitsfile *infptr, fitsfile *outfptr, int *status)
 	    		    &cvlamem,  &compmemlen, realloc, &dlen, status);        
 		    } else {
 			  /* this should not happen */
-			  ffpmsg(" Error: unknown compression algorthm");
+			  ffpmsg(" Error: unknown compression algorithm");
 			  free(vlamem); free(cdescript); free(cm_buffer); free(cvlamem);
 			  *status = DATA_COMPRESSION_ERR;
 			  return(*status);
@@ -8608,7 +8608,7 @@ int fits_compress_table(fitsfile *infptr, fitsfile *outfptr, int *status)
   	            dlen = fits_rcomp_byte ((signed char *)(cm_buffer + cm_colstart[ii]), datasize, (unsigned char *) cvlamem,
                        datasize * 2, 32);
 	        } else {  /* this should not happen */
-                    ffpmsg(" Error: cannot compress this column type with the RICE algorthm");
+                    ffpmsg(" Error: cannot compress this column type with the RICE algorithm");
 		    free(cvlamem);  free(cm_buffer);
 	            *status = DATA_COMPRESSION_ERR;
 	            return(*status);
@@ -8805,7 +8805,7 @@ int fits_uncompress_table(fitsfile *infptr, fitsfile *outfptr, int *status)
     fits_modify_name(outfptr, "ZDATASUM", "DATASUM", &tstatus);
 
     /* ================================================================================== */
-    /* determine compression paramters for each column and write column-specific keywords */
+    /* determine compression parameters for each column and write column-specific keywords */
     /* ================================================================================== */
     for (ii = 0; ii < ncols; ii++) {
 
@@ -9267,7 +9267,7 @@ int fits_uncompress_table(fitsfile *infptr, fitsfile *outfptr, int *status)
 					(int) vlalen, 32);
 				} else {
 				    /* this should not happen */
-				    ffpmsg(" Error: cannot uncompress this column type with the RICE algorthm");
+				    ffpmsg(" Error: cannot uncompress this column type with the RICE algorithm");
 
 				    *status = DATA_DECOMPRESSION_ERR;
 			            free(uncompressed_vla); free(compressed_vla); free(rm_buffer);  free(cm_buffer);
@@ -9292,7 +9292,7 @@ int fits_uncompress_table(fitsfile *infptr, fitsfile *outfptr, int *status)
 
 			    } else {
 				/* this should not happen */
-				ffpmsg(" Error: unknown compression algorthm");
+				ffpmsg(" Error: unknown compression algorithm");
 			        free(uncompressed_vla); free(compressed_vla); free(rm_buffer);  free(cm_buffer);
 				*status = DATA_COMPRESSION_ERR;
 				return(*status);
@@ -9574,7 +9574,7 @@ in place. This will overwrite the input array with the new longer array starting
 at the same memory location.  
 
 Note that aliasing the same memory location with pointers of different datatypes is
-not allowed in strict ANSI C99, however it is  used here for efficency. In principle,
+not allowed in strict ANSI C99, however it is  used here for efficiency. In principle,
 one could simply copy the input array in reverse order to the output array,
 but this only works if the compiler performs the operation in strict order.  Certain
 compiler optimization techniques may vioate this assumption.  Therefore, we first
@@ -9637,7 +9637,7 @@ in place. This will overwrite the input array with the new longer array starting
 at the same memory location.  
 
 Note that aliasing the same memory location with pointers of different datatypes is
-not allowed in strict ANSI C99, however it is  used here for efficency. In principle,
+not allowed in strict ANSI C99, however it is  used here for efficiency. In principle,
 one could simply copy the input array in reverse order to the output array,
 but this only works if the compiler performs the operation in strict order.  Certain
 compiler optimization techniques may vioate this assumption.  Therefore, we first
@@ -9701,7 +9701,7 @@ in place. This will overwrite the input array with the new longer array starting
 at the same memory location.  
 
 Note that aliasing the same memory location with pointers of different datatypes is
-not allowed in strict ANSI C99, however it is  used here for efficency. In principle,
+not allowed in strict ANSI C99, however it is  used here for efficiency. In principle,
 one could simply copy the input array in reverse order to the output array,
 but this only works if the compiler performs the operation in strict order.  Certain
 compiler optimization techniques may vioate this assumption.  Therefore, we first
@@ -9765,7 +9765,7 @@ in place. This will overwrite the input array with the new longer array starting
 at the same memory location.  
 
 Note that aliasing the same memory location with pointers of different datatypes is
-not allowed in strict ANSI C99, however it is  used here for efficency. In principle,
+not allowed in strict ANSI C99, however it is  used here for efficiency. In principle,
 one could simply copy the input array in reverse order to the output array,
 but this only works if the compiler performs the operation in strict order.  Certain
 compiler optimization techniques may vioate this assumption.  Therefore, we first
@@ -9829,7 +9829,7 @@ in place. This will overwrite the input array with the new longer array starting
 at the same memory location.  
 
 Note that aliasing the same memory location with pointers of different datatypes is
-not allowed in strict ANSI C99, however it is  used here for efficency. In principle,
+not allowed in strict ANSI C99, however it is  used here for efficiency. In principle,
 one could simply copy the input array in reverse order to the output array,
 but this only works if the compiler performs the operation in strict order.  Certain
 compiler optimization techniques may vioate this assumption.  Therefore, we first

--- a/iraffits.c
+++ b/iraffits.c
@@ -1597,7 +1597,7 @@ char *keyword;	/* character string containing the name of the variable
 	else if (nextchar != 61 && nextchar > 32 && nextchar < 127)
 	    headnext = loc + 1;
 
-	/* If preceeding characters in line are not blanks, keep searching */
+	/* If preceding characters in line are not blanks, keep searching */
 	else {
 	    line = loc - icol;
 	    for (lc = line; lc < loc; lc++) {
@@ -1692,7 +1692,7 @@ char *keyword;	/* character string containing the name of the variable
 	else if (nextchar != 61 && nextchar > 32 && nextchar < 127)
 	    headnext = loc + 1;
 
-	/* If preceeding characters in line are not blanks, keep searching */
+	/* If preceding characters in line are not blanks, keep searching */
 	else {
 	    line = loc - icol;
 	    for (lc = line; lc < loc; lc++) {

--- a/iter_c.c
+++ b/iter_c.c
@@ -106,7 +106,7 @@ int writehisto(long totaln, long offset, long firstn, long nvalues,
     fits_iter_set_by_name(&cols[0], tblptr, "X", TLONG,  InputCol);
     fits_iter_set_by_name(&cols[1], tblptr, "Y", TLONG, InputCol);
 
-    rows_per_loop = 0;  /* take default number of rows per interation */
+    rows_per_loop = 0;  /* take default number of rows per iteration */
     rowoffset = 0;     
 
     /* calculate the histogram */
@@ -123,7 +123,7 @@ int calchisto(long totalrows, long offset, long firstrow, long nrows,
              int ncols, iteratorCol *cols, void *userPointer)
 
 /*
-   Interator work function that calculates values for the 2D histogram.
+   Iterator work function that calculates values for the 2D histogram.
 */
 {
     extern long xsize, ysize, xbinsize, ybinsize;

--- a/putcol.c
+++ b/putcol.c
@@ -23,7 +23,7 @@ int ffppx(  fitsfile *fptr,  /* I - FITS file pointer                       */
   and scaling will be performed if necessary (e.g, if the datatype of
   the FITS array is not the same as the array being written). 
   
-  This routine is simillar to ffppr, except it supports writing to 
+  This routine is similar to ffppr, except it supports writing to 
   large images with more than 2**31 pixels.
 */
 {
@@ -113,7 +113,7 @@ int ffppxll(  fitsfile *fptr,  /* I - FITS file pointer                       */
   and scaling will be performed if necessary (e.g, if the datatype of
   the FITS array is not the same as the array being written). 
   
-  This routine is simillar to ffppr, except it supports writing to 
+  This routine is similar to ffppr, except it supports writing to 
   large images with more than 2**31 pixels.
 */
 {
@@ -1118,7 +1118,7 @@ int ffiter(int n_cols,
 
     if (n_cols  < 0 || n_cols > 999 )
     {
-        ffpmsg("Illegal number of columms (ffiter)");
+        ffpmsg("Illegal number of columns (ffiter)");
         return(*status = BAD_COL_NUM);  /* negative number of columns */
     }
 
@@ -1404,7 +1404,7 @@ int ffiter(int n_cols,
 		}
         }
 
-        /* Special case: interprete 'X' column as 'B' */
+        /* Special case: interpret 'X' column as 'B' */
         if (abs(typecode) == TBIT)
         {
             typecode  = typecode / TBIT * TBYTE;
@@ -1442,7 +1442,7 @@ int ffiter(int n_cols,
         {
 	    if (typecode < 0) 
 	    {
-              /* get max size of the variable length vector; dont't trust the value
+              /* get max size of the variable length vector; don't trust the value
 	         given by the TFORM keyword  */
 	      rept = 1;
 	      for (ii = 0; ii < totaln; ii++) {
@@ -1871,7 +1871,7 @@ int ffiter(int n_cols,
       if (*status > 0 || *status < -1 ) 
          break;   /* looks like an error occurred; quit immediately */
 
-      /*  write output columns  before quiting if status = -1 */
+      /*  write output columns  before quitting if status = -1 */
       tstatus = 0;
       for (jj = 0; jj < n_cols; jj++)
       {
@@ -1906,7 +1906,7 @@ int ffiter(int n_cols,
 	    	if (ffgtcl(cols[jj].fptr, cols[jj].colnum, &typecode, &rept,&width, status) > 0)
 		    goto cleanup;
 		    
-		if (typecode<0)  /* variable length array colum */
+		if (typecode<0)  /* variable length array column */
 		{
 		   ffgdes(cols[jj].fptr, cols[jj].colnum, frow,&cols[jj].repeat, NULL,status);
 		}

--- a/putcolb.c
+++ b/putcolb.c
@@ -707,7 +707,7 @@ int ffpextn( fitsfile *fptr,        /* I - FITS file pointer                    
             void *buffer,          /* I - stream of bytes to write                 */
             int  *status)          /* IO - error status                            */
 /*
-  Write a stream of bytes to the current FITS HDU.  This primative routine is mainly
+  Write a stream of bytes to the current FITS HDU.  This primitive routine is mainly
   for writing non-standard "conforming" extensions and should not be used
   for standard IMAGE, TABLE or BINTABLE extensions.
 */

--- a/putcold.c
+++ b/putcold.c
@@ -571,7 +571,7 @@ int ffpclm( fitsfile *fptr,   /* I - FITS file pointer                       */
   The input array of values will be converted to the datatype of the column
   if necessary, but normally complex values should only be written to a binary
   table with TFORMn = 'rM' where r is an optional repeat count. The TSCALn and
-  TZERO keywords should not be used with complex numbers because mathmatically
+  TZERO keywords should not be used with complex numbers because mathematically
   the scaling should only be applied to the real (first) component of the
   complex value.
 */

--- a/putcole.c
+++ b/putcole.c
@@ -585,7 +585,7 @@ int ffpclc( fitsfile *fptr,  /* I - FITS file pointer                       */
   The input array of values will be converted to the datatype of the column
   if necessary, but normally complex values should only be written to a binary
   table with TFORMn = 'rC' where r is an optional repeat count. The TSCALn and
-  TZERO keywords should not be used with complex numbers because mathmatically
+  TZERO keywords should not be used with complex numbers because mathematically
   the scaling should only be applied to the real (first) component of the
   complex value.
 */

--- a/putcoll.c
+++ b/putcoll.c
@@ -303,7 +303,7 @@ int ffpclx( fitsfile *fptr,  /* I - FITS file pointer                       */
         repeat = fbit + nbit -1;
 
         /* write the number of elements and the starting offset.    */
-        /* Note: ffgcprll previous wrote the descripter, but with the */
+        /* Note: ffgcprll previous wrote the descriptor, but with the */
         /* wrong repeat value  (gave bytes instead of bits).        */
         /* Make sure to not change the current heap offset value!  */
 

--- a/putkey.c
+++ b/putkey.c
@@ -520,7 +520,7 @@ int ffpkls( fitsfile *fptr,     /* I - FITS file pointer        */
 	
         if (commlen > 0 && remain + nquote < 69 && remain + nquote + commlen > 65) 
 	{
-            if (nchar > 18) { /* only false if there are a rediculous number of quotes in the string */
+            if (nchar > 18) { /* only false if there are a ridiculous number of quotes in the string */
 	        nchar = remain - 15;  /* force continuation onto another card, so that */
 		                      /* there is room for a comment up to 47 chara long */
                 nocomment = 1;  /* don't write the comment string this time */
@@ -3034,7 +3034,7 @@ int ffs2c(const char *instr, /* I - null terminated input string  */
         if (instr[ii] == '\'')
         {
             jj++;
-            outstr[jj]='\'';   /* duplicate any apostrophies in the input */
+            outstr[jj]='\'';   /* duplicate any apostrophes in the input */
         }
     }
 
@@ -3152,7 +3152,7 @@ int ffr2e(float fval,  /* I - value to be converted to a string */
         }
         else if ( !strchr(cval, '.') && !strchr(cval,'E') && strlen(cval) < FLEN_VALUE-1 )
         {
-            /* add decimal point if necessary to distinquish from integer */
+            /* add decimal point if necessary to distinguish from integer */
             strcat(cval, ".");
         }
     }
@@ -3260,7 +3260,7 @@ int ffd2e(double dval,  /* I - value to be converted to a string */
         }
         else if ( !strchr(cval, '.') && !strchr(cval,'E') && strlen(cval) < FLEN_VALUE-1)
         {
-            /* add decimal point if necessary to distinquish from integer */
+            /* add decimal point if necessary to distinguish from integer */
             strcat(cval, ".");
         }
     }

--- a/quantize.c
+++ b/quantize.c
@@ -156,7 +156,7 @@ If the function value is zero, the data were not copied to idata.
 	    /* negative value represents the absolute quantization level */
 	    delta = -qlevel;
 
-	    /* only nned to calculate the min and max values */
+	    /* only need to calculate the min and max values */
 	    FnNoise3_float(fdata, nxpix, nypix, nullcheck, in_null_value, &ngood,
 	        &minval, &maxval, 0, &status);      
  	}
@@ -345,7 +345,7 @@ If the function value is zero, the data were not copied to idata.
 	    /* negative value represents the absolute quantization level */
 	    delta = -qlevel;
 
-	    /* only nned to calculate the min and max values */
+	    /* only need to calculate the min and max values */
 	    FnNoise3_double(fdata, nxpix, nypix, nullcheck, in_null_value, &ngood,
 	        &minval, &maxval, 0, &status);      
  	}

--- a/region.c
+++ b/region.c
@@ -579,8 +579,8 @@ int fits_read_ascii_region( const char *filename,
 	      coords[7] = coords[6];
 	    }
 
-            /* Also, correct the position angle for any WCS rotation:  */
-            /*    If regions are specified in WCS coordintes, then the angles */
+            /* Also, correct the position angle for any WCS rotation: */
+            /*    If regions are specified in WCS coordinates, then the angles */
             /*    are relative to the WCS system, not the pixel X,Y system */
 
 	    if( cFmt!=pixel_fmt ) {	    

--- a/scalnull.c
+++ b/scalnull.c
@@ -9,7 +9,7 @@
 #include "fitsio2.h"
 /*--------------------------------------------------------------------------*/
 int ffpthp(fitsfile *fptr,      /* I - FITS file pointer */
-           long theap,          /* I - starting addrss for the heap */
+           long theap,          /* I - starting address for the heap */
            int *status)         /* IO - error status     */
 /*
   Define the starting address for the heap for a binary table.

--- a/testprog.tpt
+++ b/testprog.tpt
@@ -1,7 +1,7 @@
 tmpcard1  1001 this is the 1st template card 
 tmpcard2  ABCD this is the 2nd template card
 tmpcard3  1001.23 this is the 3rd template card
-tmpcard4  1001.45 this is the 4rd template card
+tmpcard4  1001.45 this is the 4th template card
 comment this is the 5th template card
 history this is the 6th template card
 tmpcard7 =            / comment for null keyword

--- a/wcssub.c
+++ b/wcssub.c
@@ -259,7 +259,7 @@ int ffgics(fitsfile *fptr,    /* I - FITS file pointer           */
             phia = temp;
 
             /* there is a possible 180 degree ambiguity in the angles */
-            /* so add 180 degress to the smaller value if the values  */
+            /* so add 180 degrees to the smaller value if the values  */
             /* differ by more than 90 degrees = pi/2 radians.         */
             /* (Later, we may decide to take the other solution by    */
             /* subtracting 180 degrees from the larger value).        */
@@ -348,7 +348,7 @@ int ffgics(fitsfile *fptr,    /* I - FITS file pointer           */
                 phia = temp;
 
                 /* there is a possible 180 degree ambiguity in the angles */
-                /* so add 180 degress to the smaller value if the values  */
+                /* so add 180 degrees to the smaller value if the values  */
                 /* differ by more than 90 degrees = pi/2 radians.         */
                 /* (Later, we may decide to take the other solution by    */
                 /* subtracting 180 degrees from the larger value).        */
@@ -526,7 +526,7 @@ int ffgicsa(fitsfile *fptr,    /* I - FITS file pointer           */
             phia = temp;
 
             /* there is a possible 180 degree ambiguity in the angles */
-            /* so add 180 degress to the smaller value if the values  */
+            /* so add 180 degrees to the smaller value if the values  */
             /* differ by more than 90 degrees = pi/2 radians.         */
             /* (Later, we may decide to take the other solution by    */
             /* subtracting 180 degrees from the larger value).        */
@@ -631,7 +631,7 @@ int ffgicsa(fitsfile *fptr,    /* I - FITS file pointer           */
                 phia = temp;
 
                 /* there is a possible 180 degree ambiguity in the angles */
-                /* so add 180 degress to the smaller value if the values  */
+                /* so add 180 degrees to the smaller value if the values  */
                 /* differ by more than 90 degrees = pi/2 radians.         */
                 /* (Later, we may decide to take the other solution by    */
                 /* subtracting 180 degrees from the larger value).        */

--- a/windumpexts.c
+++ b/windumpexts.c
@@ -161,7 +161,7 @@ DumpSymbolTable(PIMAGE_SYMBOL pSymbolTable, FILE *fout, unsigned cSymbols)
     PSTR stringTable;
     char sectionName[10];
 	
-    fprintf(fout, "Symbol Table - %X entries  (* = auxillary symbol)\n",
+    fprintf(fout, "Symbol Table - %X entries  (* = auxiliary symbol)\n",
 	    cSymbols);
 
     fprintf(fout, 

--- a/zlib/deflate.h
+++ b/zlib/deflate.h
@@ -186,7 +186,7 @@ typedef struct internal_state {
     int nice_match; /* Stop searching when current match exceeds this */
 
                 /* used by trees.c: */
-    /* Didn't use ct_data typedef below to supress compiler warning */
+    /* Didn't use ct_data typedef below to suppress compiler warning */
     struct ct_data_s dyn_ltree[HEAP_SIZE];   /* literal and length tree */
     struct ct_data_s dyn_dtree[2*D_CODES+1]; /* distance tree */
     struct ct_data_s bl_tree[2*BL_CODES+1];  /* Huffman tree for bit lengths */

--- a/zlib/inftrees.h
+++ b/zlib/inftrees.h
@@ -38,7 +38,7 @@ typedef struct {
 /* Maximum size of the dynamic table.  The maximum number of code structures is
    1444, which is the sum of 852 for literal/length codes and 592 for distance
    codes.  These values were found by exhaustive searches using the program
-   examples/enough.c found in the zlib distribtution.  The arguments to that
+   examples/enough.c found in the zlib distributions.  The arguments to that
    program are the number of symbols, the initial root table size, and the
    maximum bit length of a code.  "enough 286 9 15" for literal/length codes
    returns returns 852, and "enough 30 6 15" for distance codes returns 592.

--- a/zlib/trees.c
+++ b/zlib/trees.c
@@ -317,7 +317,7 @@ local void tr_static_init()
 }
 
 /* ===========================================================================
- * Genererate the file trees.h describing the static trees.
+ * Generate the file trees.h describing the static trees.
  */
 #ifdef GEN_TREES_H
 #  ifndef DEBUG

--- a/zlib/zcompress.c
+++ b/zlib/zcompress.c
@@ -385,7 +385,7 @@ int compress2mem_from_mem(
     c_stream.opaque = (voidpf)0;
 
     /* Initialize the compression.  The argument (15+16) tells the 
-       compressor that we are to use the gzip algorythm.
+       compressor that we are to use the gzip algorithm.
        Also use Z_BEST_SPEED for maximum speed with very minor loss
        in compression factor. */
     err = deflateInit2(&c_stream, Z_BEST_SPEED, Z_DEFLATED,
@@ -467,7 +467,7 @@ int compress2file_from_mem(
     c_stream.opaque = (voidpf)0;
 
     /* Initialize the compression.  The argument (15+16) tells the 
-       compressor that we are to use the gzip algorythm.
+       compressor that we are to use the gzip algorithm.
        Also use Z_BEST_SPEED for maximum speed with very minor loss
        in compression factor. */
     err = deflateInit2(&c_stream, Z_BEST_SPEED, Z_DEFLATED,

--- a/zlib/zlib.h
+++ b/zlib/zlib.h
@@ -962,7 +962,7 @@ ZEXTERN int ZEXPORT inflateBackInit OF((z_streamp strm, int windowBits,
      See inflateBack() for the usage of these routines.
 
      inflateBackInit will return Z_OK on success, Z_STREAM_ERROR if any of
-   the paramaters are invalid, Z_MEM_ERROR if the internal state could not be
+   the parameters are invalid, Z_MEM_ERROR if the internal state could not be
    allocated, or Z_VERSION_ERROR if the version of the library does not match
    the version of the header file.
 */
@@ -1325,7 +1325,7 @@ ZEXTERN int ZEXPORT gzflush OF((gzFile file, int flush));
      If the flush parameter is Z_FINISH, the remaining data is written and the
    gzip stream is completed in the output.  If gzwrite() is called again, a new
    gzip stream will be started in the output.  gzread() is able to read such
-   concatented gzip streams.
+   concatenated gzip streams.
 
      gzflush should be called only when strictly necessary because it will
    degrade compression if called too often.

--- a/zlib/zuncompress.c
+++ b/zlib/zuncompress.c
@@ -163,7 +163,7 @@ int zuncompress2mem(char *filename,  /* name of input file                 */
     method = COMPRESSED;
     last_member = 1;
 
-    /* do the uncompression */
+    /* do the decompression */
     if ((*work)(ifd, ofd) != OK) {
         method = -1; /* force cleanup */
         *status = 414;    /* report some sort of decompression error */
@@ -175,7 +175,7 @@ int zuncompress2mem(char *filename,  /* name of input file                 */
 }
 /*=========================================================================*/
 /*=========================================================================*/
-/* this marks the begining of the original file 'unlzw.c'                  */
+/* this marks the beginning of the original file 'unlzw.c'                 */
 /*=========================================================================*/
 /*=========================================================================*/
 


### PR DESCRIPTION
Found via `codespell -q 3 -L ba,dout,hist,livetime,msdos,nax,nd,parms,te,thex`